### PR TITLE
🔗 :: 기업 탐색 스크롤 초기화 오류

### DIFF
--- a/Projects/Presentation/Sources/Company/CompanyViewController.swift
+++ b/Projects/Presentation/Sources/Company/CompanyViewController.swift
@@ -8,7 +8,7 @@ import Core
 import DesignSystem
 
 public final class CompanyViewController: BaseViewController<CompanyViewModel> {
-    private var viewWillappearWithTap: (() -> Void)?
+    private var viewWillAppearWithTap: (() -> Void)?
     private var isTabNavigation: Bool = true
     private let searchButtonDidTap = PublishRelay<Void>()
     private let companyTableView = UITableView().then {
@@ -73,12 +73,12 @@ public final class CompanyViewController: BaseViewController<CompanyViewModel> {
                 self.hideTabbar()
                 self.setSmallTitle(title: "기업 탐색")
                 if self.isTabNavigation {
-                    self.viewWillappearWithTap?()
+                    self.viewWillAppearWithTap?()
                 }
                 self.isTabNavigation = true
             }
             .disposed(by: disposeBag)
-        
+
         searchButton.rx.tap
             .subscribe(onNext: { _ in
                 self.searchButtonDidTap.accept(())

--- a/Projects/Presentation/Sources/Company/CompanyViewController.swift
+++ b/Projects/Presentation/Sources/Company/CompanyViewController.swift
@@ -7,7 +7,9 @@ import Then
 import Core
 import DesignSystem
 
-public class CompanyViewController: BaseViewController<CompanyViewModel> {
+public final class CompanyViewController: BaseViewController<CompanyViewModel> {
+    private var viewWillappearWithTap: (() -> Void)?
+    private var isTabNavigation: Bool = true
     private let searchButtonDidTap = PublishRelay<Void>()
     private let companyTableView = UITableView().then {
         $0.register(
@@ -36,7 +38,7 @@ public class CompanyViewController: BaseViewController<CompanyViewModel> {
 
     public override func bind() {
         let input = CompanyViewModel.Input(
-            viewAppear: self.viewWillAppearPublisher,
+            viewAppear: self.viewDidLoadPublisher,
             pageChange: companyTableView.rx.willDisplayCell
                 .filter {
                     $0.indexPath.row == self.companyTableView.numberOfRows(
@@ -44,7 +46,10 @@ public class CompanyViewController: BaseViewController<CompanyViewModel> {
                     ) - 1
                 },
             companyTableViewCellDidTap: companyTableView.rx.modelSelected(CompanyEntity.self)
-                .map { $0.companyID },
+                .map { $0.companyID }
+                .do(onNext: { _ in
+                    self.isTabNavigation = false
+                }),
             searchButtonDidTap: searchButtonDidTap
         )
 
@@ -63,12 +68,17 @@ public class CompanyViewController: BaseViewController<CompanyViewModel> {
     }
 
     public override func configureViewController() {
-        viewWillAppearPublisher
+        viewWillAppearPublisher.asObservable()
             .bind {
                 self.hideTabbar()
+                self.setSmallTitle(title: "기업 탐색")
+                if self.isTabNavigation {
+                    self.viewWillappearWithTap?()
+                }
+                self.isTabNavigation = true
             }
             .disposed(by: disposeBag)
-
+        
         searchButton.rx.tap
             .subscribe(onNext: { _ in
                 self.searchButtonDidTap.accept(())
@@ -77,7 +87,6 @@ public class CompanyViewController: BaseViewController<CompanyViewModel> {
     }
 
     public override func configureNavigation() {
-        self.setSmallTitle(title: "기업 탐색")
         self.navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = [
             UIBarButtonItem(customView: searchButton)

--- a/Projects/Presentation/Sources/Company/CompanyViewModel.swift
+++ b/Projects/Presentation/Sources/Company/CompanyViewModel.swift
@@ -39,6 +39,7 @@ public final class CompanyViewModel: BaseViewModel, Stepper {
             .bind(onNext: {
                 self.companyList.accept([])
                 self.companyList.accept(self.companyList.value + $0)
+                self.pageCount = 1
             })
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 개요
-  기업 탐색 스크롤 초기화 오류

## 작업사항
-  기업 탐색 스크롤 초기화 오류 해결

## UI
<img src="<!-- 이미지 링크 작성 -->" width="150px"></img>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 화면 진입 시 탭 네비게이션 여부를 추적하여 UI 동작을 세분화했습니다.

- **버그 수정**
  - 기업 목록 초기화 후 페이지 카운트가 올바르게 1로 재설정되어 데이터 새로고침 시 오류를 방지합니다.

- **스타일**
  - 화면 진입 시 작은 타이틀 "기업 탐색"이 탭 네비게이션 상태에 따라 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->