### PR TITLE
🔗 :: (#303) 현황 보러 가기 버튼 layout 수정

### DIFF
--- a/Projects/Presentation/Sources/Home/Components/Cell/BannerCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Home/Components/Cell/BannerCollectionViewCell.swift
@@ -64,8 +64,8 @@ final class BannerCollectionViewCell: BaseCollectionViewCell<FetchBannerEntity> 
         }
 
         employStatusButton.snp.makeConstraints {
-            $0.top.equalTo(passLabel.snp.bottom).offset(24)
             $0.leading.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().inset(18)
             $0.width.equalTo(151)
             $0.height.equalTo(40)
         }


### PR DESCRIPTION
## 개요
현황 보러 가기 버튼 layout 수정

## 작업사항
- 현황 보러 가기 버튼 layout 수정

## UI
<img src="https://github.com/user-attachments/assets/f7046009-eb78-4943-bd12-9220ae160ec7" width="150px"></img>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - employStatusButton의 위치가 하단 여백 18에 맞춰 조정되어 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->