### PR TITLE
🔗 :: (#411) 모집의뢰서 지역 필터링 추가

### DIFF
--- a/Projects/Core/Sources/Steps/RecruitmentFilterStep.swift
+++ b/Projects/Core/Sources/Steps/RecruitmentFilterStep.swift
@@ -2,5 +2,5 @@ import RxFlow
 
 public enum RecruitmentFilterStep: Step {
     case recruitmentFilterIsRequired
-    case popToRecruitment(jobCode: String?, techCode: [String]?, years: [String]?, status: String?)
+    case popToRecruitment(jobCode: String?, techCode: [String]?, years: [String]?, region: String?, status: String?)
 }

--- a/Projects/Data/Sources/DataSource/API/RecruitmentsAPI.swift
+++ b/Projects/Data/Sources/DataSource/API/RecruitmentsAPI.swift
@@ -11,6 +11,7 @@ enum RecruitmentsAPI {
         name: String?,
         winterIntern: Bool?,
         years: [String]?,
+        region: String?,
         status: String?,
         sortType: String?
     )
@@ -42,7 +43,7 @@ extension RecruitmentsAPI: JobisAPI {
 
     var task: Moya.Task {
         switch self {
-        case let .fetchRecruitmentList(page, jobCode, techCode, name, winterIntern, years, status, sortType):
+        case let .fetchRecruitmentList(page, jobCode, techCode, name, winterIntern, years, region, status, sortType):
             return .requestParameters(parameters: [
                 "page": page,
                 "job_code": jobCode ?? " ",
@@ -50,6 +51,7 @@ extension RecruitmentsAPI: JobisAPI {
                 "name": name ?? "",
                 "winter_intern": winterIntern ?? false,
                 "years": years?.joined(separator: ",") ?? "",
+                "region": region ?? "",
                 "status": status ?? "",
                 "sort_type": sortType ?? ""
             ], encoding: URLEncoding.queryString)

--- a/Projects/Data/Sources/DataSource/Remote/RemoteRecruitmentsDataSource.swift
+++ b/Projects/Data/Sources/DataSource/Remote/RemoteRecruitmentsDataSource.swift
@@ -10,6 +10,7 @@ protocol RemoteRecruitmentsDataSource {
         name: String?,
         winterIntern: Bool?,
         years: [String]?,
+        region: String?,
         status: String?,
         sortType: String?
     ) -> Single<[RecruitmentEntity]>
@@ -29,6 +30,7 @@ final class RemoteRecruitmentsDataSourceImpl: RemoteBaseDataSource<RecruitmentsA
         name: String?,
         winterIntern: Bool?,
         years: [String]?,
+        region: String?,
         status: String?,
         sortType: String?
     ) -> Single<[RecruitmentEntity]> {
@@ -39,6 +41,7 @@ final class RemoteRecruitmentsDataSourceImpl: RemoteBaseDataSource<RecruitmentsA
             name: name,
             winterIntern: winterIntern,
             years: years,
+            region: region,
             status: status,
             sortType: sortType
         ))

--- a/Projects/Data/Sources/Repositories/RecruitmentsRepositoryImpl.swift
+++ b/Projects/Data/Sources/Repositories/RecruitmentsRepositoryImpl.swift
@@ -19,6 +19,7 @@ struct RecruitmentsRepositoryImpl: RecruitmentsRepository {
         name: String?,
         winterIntern: Bool?,
         years: [String]?,
+        region: String?,
         status: String?,
         sortType: String?
     ) -> Single<[RecruitmentEntity]> {
@@ -29,6 +30,7 @@ struct RecruitmentsRepositoryImpl: RecruitmentsRepository {
             name: name,
             winterIntern: winterIntern,
             years: years,
+            region: region,
             status: status,
             sortType: sortType
         )

--- a/Projects/Domain/Sources/Repositories/RecruitmentsRepository.swift
+++ b/Projects/Domain/Sources/Repositories/RecruitmentsRepository.swift
@@ -9,6 +9,7 @@ public protocol RecruitmentsRepository {
         name: String?,
         winterIntern: Bool?,
         years: [String]?,
+        region: String?,
         status: String?,
         sortType: String?
     ) -> Single<[RecruitmentEntity]>

--- a/Projects/Domain/Sources/UseCases/Recruitments/FetchRecruitmentListUseCase.swift
+++ b/Projects/Domain/Sources/UseCases/Recruitments/FetchRecruitmentListUseCase.swift
@@ -14,6 +14,7 @@ public struct FetchRecruitmentListUseCase {
         name: String? = nil,
         winterIntern: Bool? = nil,
         years: [String]? = nil,
+        region: String? = nil,
         status: String? = nil,
         sortType: String? = nil
     ) -> Single<[RecruitmentEntity]> {
@@ -24,6 +25,7 @@ public struct FetchRecruitmentListUseCase {
             name: name,
             winterIntern: winterIntern,
             years: years,
+            region: region,
             status: status,
             sortType: sortType
         )

--- a/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
@@ -43,7 +43,7 @@ private extension RecruitmentFilterFlow {
 
         // Update filter options via reactor action
         recruitmentPopView?.reactor.action.onNext(
-            .updateFilterOptions(jobCode: jobCode, techCode: techCode, years: years, status: status)
+            .updateFilterOptions(jobCode: jobCode, techCode: techCode, years: years, region: region, status: status)
         )
         recruitmentPopView?.reactor.action.onNext(.fetchRecruitmentList)
 

--- a/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
@@ -23,8 +23,8 @@ public final class RecruitmentFilterFlow: Flow {
         case .recruitmentFilterIsRequired:
             return navigateToRecruitmentFilter()
 
-        case let .popToRecruitment(jobCode, techCode, years, status):
-            return popToRecruitment(jobCode: jobCode ?? "", techCode: techCode, years: years, status: status)
+        case let .popToRecruitment(jobCode, techCode, years, region, status):
+            return popToRecruitment(jobCode: jobCode ?? "", techCode: techCode, years: years, region: region, status: status)
         }
     }
 }
@@ -37,7 +37,7 @@ private extension RecruitmentFilterFlow {
         ))
     }
 
-    func popToRecruitment(jobCode: String, techCode: [String]?, years: [String]?, status: String?) -> FlowContributors {
+    func popToRecruitment(jobCode: String, techCode: [String]?, years: [String]?, region: String?, status: String?) -> FlowContributors {
         let recruitmentPopView = self.rootViewController.navigationController?.viewControllers.first as? RecruitmentViewController
         let winterInternPopView = self.rootViewController.navigationController?.viewControllers.first(where: { $0 is WinterInternViewController}) as? WinterInternViewController
 

--- a/Projects/Presentation/Sources/Recruitment/RecruitmentReactor.swift
+++ b/Projects/Presentation/Sources/Recruitment/RecruitmentReactor.swift
@@ -27,7 +27,7 @@ public final class RecruitmentReactor: BaseReactor, Stepper {
         case recruitmentDidSelect(Int)
         case searchButtonDidTap
         case filterButtonDidTap
-        case updateFilterOptions(jobCode: String, techCode: [String]?, years: [String]?, status: String?)
+        case updateFilterOptions(jobCode: String, techCode: [String]?, years: [String]?, region: String?,  status: String?)
         case updateSortOption(String)
     }
 
@@ -37,7 +37,7 @@ public final class RecruitmentReactor: BaseReactor, Stepper {
         case updateBookmark(Int)
         case incrementPageCount
         case resetPageCount
-        case setFilterOptions(jobCode: String, techCode: [String]?, years: [String]?, status: String?)
+        case setFilterOptions(jobCode: String, techCode: [String]?, years: [String]?, region: String?, status: String?)
         case setLoading(Bool)
         case setSortType(RecruitmentSortType?)
     }
@@ -47,6 +47,7 @@ public final class RecruitmentReactor: BaseReactor, Stepper {
         var jobCode: String = ""
         var techCode: [String]?
         var years: [String]?
+        var region: String?
         var status: String?
         var sortType: RecruitmentSortType?
         var pageCount: Int = 1
@@ -66,6 +67,7 @@ extension RecruitmentReactor {
                     jobCode: currentState.jobCode,
                     techCode: currentState.techCode,
                     years: currentState.years,
+                    region: currentState.region,
                     status: currentState.status,
                     sortType: currentState.sortType?.rawValue
                 )
@@ -85,6 +87,7 @@ extension RecruitmentReactor {
                 jobCode: currentState.jobCode,
                 techCode: currentState.techCode,
                 years: currentState.years,
+                region: currentState.region,
                 status: currentState.status,
                 sortType: currentState.sortType?.rawValue
             )
@@ -118,8 +121,8 @@ extension RecruitmentReactor {
             steps.accept(RecruitmentStep.recruitmentFilterIsRequired)
             return .empty()
 
-        case let .updateFilterOptions(jobCode, techCode, years, status):
-            return .just(.setFilterOptions(jobCode: jobCode, techCode: techCode, years: years, status: status))
+        case let .updateFilterOptions(jobCode, techCode, years, region, status):
+            return .just(.setFilterOptions(jobCode: jobCode, techCode: techCode, years: years, region: region, status: status))
 
         case let .updateSortOption(option):
             let sortType = RecruitmentSortType(localizedString: option)
@@ -132,6 +135,7 @@ extension RecruitmentReactor {
                     jobCode: currentState.jobCode,
                     techCode: currentState.techCode,
                     years: currentState.years,
+                    region: currentState.region,
                     status: currentState.status,
                     sortType: sortType?.rawValue
                 )
@@ -171,10 +175,11 @@ extension RecruitmentReactor {
         case .resetPageCount:
             newState.pageCount = 1
 
-        case let .setFilterOptions(jobCode, techCode, years, status):
+        case let .setFilterOptions(jobCode, techCode, years, region, status):
             newState.jobCode = jobCode
             newState.techCode = techCode
             newState.years = years
+            newState.region = region
             newState.status = status
 
         case let .setLoading(isLoading):

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
@@ -107,7 +107,7 @@ extension RecruitmentFilterReactor {
                 jobCode: currentState.jobCode,
                 techCode: currentState.techCode,
                 years: currentState.years,
-                region: currentState.regionCode,
+                region: mapRegion(code: currentState.regionCode),
                 status: statusString
             ))
             return .empty()
@@ -168,5 +168,12 @@ extension RecruitmentFilterReactor {
         default:
             return ""
         }
+    }
+
+    private func mapRegion(code: String) -> String {
+        guard let code = Int(code) else { return "" }
+        let allCases = LocationType.allCases
+        guard code < allCases.count else { return "" }
+        return allCases[code].rawValue
     }
 }

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
@@ -23,6 +23,7 @@ public final class RecruitmentFilterReactor: BaseReactor, Stepper {
         case fetchCodeLists
         case selectJobCode(CodeEntity)
         case selectYear(CodeEntity)
+        case selectRegion(CodeEntity)
         case selectStatus(CodeEntity)
         case filterApplyButtonDidTap
         case appendTechCode(CodeEntity)

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
@@ -47,6 +47,10 @@ public final class RecruitmentFilterReactor: BaseReactor, Stepper {
         var statusCode: Int?
         var years: [String] = []
         var techCode: [String] = []
+        var regionCode: String = ""
+        let regionList : [CodeEntity] = LocationType.allCases.enumerated().map {
+            CodeEntity(code: $0.offset, keyword: $0.element.koreanName)
+        }
         let yearList: [CodeEntity] = {
             let currentYear = Calendar.current.component(.year, from: Date())
             return (2023...currentYear).reversed().map {
@@ -99,6 +103,7 @@ extension RecruitmentFilterReactor {
                 jobCode: currentState.jobCode,
                 techCode: currentState.techCode,
                 years: currentState.years,
+                region: currentState.regionCode,
                 status: statusString
             ))
             return .empty()

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterReactor.swift
@@ -35,6 +35,7 @@ public final class RecruitmentFilterReactor: BaseReactor, Stepper {
         case setTechList([CodeEntity])
         case toggleJobCode(String)
         case toggleYear(String)
+        case toggleRegion(String)
         case toggleStatus(Int)
         case appendTechCode(String)
         case resetTechCode
@@ -48,7 +49,7 @@ public final class RecruitmentFilterReactor: BaseReactor, Stepper {
         var years: [String] = []
         var techCode: [String] = []
         var regionCode: String = ""
-        let regionList : [CodeEntity] = LocationType.allCases.enumerated().map {
+        let regionList: [CodeEntity] = LocationType.allCases.enumerated().map {
             CodeEntity(code: $0.offset, keyword: $0.element.koreanName)
         }
         let yearList: [CodeEntity] = {
@@ -94,6 +95,9 @@ extension RecruitmentFilterReactor {
         case let .selectYear(code):
             return .just(.toggleYear("\(code.code)"))
 
+        case let .selectRegion(code):
+            return .just(.toggleRegion("\(code.code)"))
+
         case let .selectStatus(code):
             return .just(.toggleStatus(code.code))
 
@@ -138,6 +142,9 @@ extension RecruitmentFilterReactor {
             } else {
                 newState.years.append(year)
             }
+
+        case let .toggleRegion(code):
+            newState.regionCode = (newState.regionCode == code) ? "" : code
 
         case let .toggleStatus(code):
             newState.statusCode = (newState.statusCode == code) ? nil : code

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
@@ -37,6 +37,22 @@ public final class RecruitmentFilterViewController: BaseReactorViewController<Re
             forCellWithReuseIdentifier: JobsCollectionViewCell.identifier
         )
     }
+    private let regionLabel = UILabel().then {
+        $0.setJobisText("지역", font: .subHeadLine, color: .GrayScale.gray70)
+    }
+    private let regionLayout = LeftAlignedCollectionViewFlowLayout().then {
+        $0.applyDefaultLayout()
+    }
+    private lazy var regionCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: regionLayout
+    ).then {
+        $0.isScrollEnabled = false
+        $0.register(
+            JobsCollectionViewCell.self,
+            forCellWithReuseIdentifier: JobsCollectionViewCell.identifier
+        )
+    }
     private let stateLabel = UILabel().then {
         $0.setJobisText("모집 상태", font: .subHeadLine, color: .GrayScale.gray70)
     }
@@ -115,6 +131,14 @@ public final class RecruitmentFilterViewController: BaseReactorViewController<Re
 
         yearCollectionView.snp.makeConstraints {
             $0.height.greaterThanOrEqualTo(yearCollectionView.contentSize.height)
+        }
+
+        regionLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(24)
+        }
+
+        regionCollectionView.snp.makeConstraints {
+            $0.height.greaterThanOrEqualTo(regionCollectionView.contentSize.height)
         }
 
         stateLabel.snp.makeConstraints {

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
@@ -186,6 +186,14 @@ public final class RecruitmentFilterViewController: BaseReactorViewController<Re
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
+        regionCollectionView.rx.modelSelected(CodeEntity.self)
+            .do(onNext: { [weak self] _ in
+                self?.regionCollectionView.reloadData()
+            })
+            .map { RecruitmentFilterReactor.Action.selectRegion($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
         stateCollectionView.rx.modelSelected(CodeEntity.self)
             .do(onNext: { [weak self] _ in
                 self?.stateCollectionView.reloadData()

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
@@ -100,6 +100,8 @@ public final class RecruitmentFilterViewController: BaseReactorViewController<Re
         [
             yearLabel,
             yearCollectionView,
+            regionLabel,
+            regionCollectionView,
             stateLabel,
             stateCollectionView,
             jobsLabel,

--- a/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
+++ b/Projects/Presentation/Sources/RecruitmentFilter/RecruitmentFilterViewController.swift
@@ -253,6 +253,17 @@ public final class RecruitmentFilterViewController: BaseReactorViewController<Re
             }
             .disposed(by: disposeBag)
 
+        reactor.state.map { $0.regionList }
+            .bind(to: regionCollectionView.rx.items(
+                cellIdentifier: JobsCollectionViewCell.identifier,
+                cellType: JobsCollectionViewCell.self
+            )) { [weak self] _, element, cell in
+                guard let self = self else { return }
+                cell.adapt(model: element)
+                cell.isCheck = self.reactor.currentState.regionCode == "\(element.code)"
+            }
+            .disposed(by: disposeBag)
+
         reactor.state.map { $0.stateList }
             .bind(to: stateCollectionView.rx.items(
                 cellIdentifier: JobsCollectionViewCell.identifier,


### PR DESCRIPTION
## 개요
> <!-- 작업 목적 및 개요 작성 -->
- 모집의뢰서 필터링에 지역 필터링 추가

## 작업사항
- [x] <!-- 작업 사항 작성 -->
 모집의뢰서 필터링에 지역 필터링 추가

## UI
<img width="150" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-17 at 19 06 11" src="https://github.com/user-attachments/assets/86c1c6c9-0c4f-469f-9700-3cacf58ea424"/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 채용 공고 필터에 **지역 필터링** 기능 추가 - 사용자가 이제 지역을 선택하여 채용 목록을 필터링할 수 있습니다.
* 채용 필터 화면에 새로운 "지역" 필터 UI 추가 - 기존의 업무, 기술, 경력, 상태 필터와 함께 지역 선택 옵션이 통합되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->