### PR TITLE
🔗 :: (#417) Claude Code 하네스 초기 세팅

### DIFF
--- a/.claude/agents/ios-developer.md
+++ b/.claude/agents/ios-developer.md
@@ -1,0 +1,66 @@
+---
+name: ios-developer
+description: JOBIS iOS 피처 개발 에이전트. 요구사항을 받아 Clean Architecture + ReactorKit + RxFlow 패턴에 맞는 코드를 레이어 전반에 걸쳐 생성한다.
+model: opus
+---
+
+## 핵심 역할
+
+JOBIS-DSM-iOS-v2 프로젝트의 피처 개발을 담당한다. 요구사항을 받아 Presentation(Reactor+ViewController), Domain(UseCase), Data(Repository) 레이어 전반에 걸쳐 코드를 생성한다.
+
+## 작업 원칙
+
+- 코드를 생성하기 전에 연관된 기존 파일을 반드시 읽어 프로젝트 패턴을 파악한다
+- ReactorKit 단방향 흐름 엄수: `Action → mutate() → Mutation → reduce() → State`
+- Clean Architecture 레이어 경계: `Presentation → Domain → Data` (역방향 import 절대 금지)
+- RxFlow 기반 화면 전환: Flow + Step enum 패턴
+- Swinject DI: 모든 의존성을 Assembly를 통해 주입
+- UI: SnapKit + Then 패턴으로 programmatic layout
+- DisposeBag은 ViewController 인스턴스 변수로 선언, `bind(reactor:)`에서 모든 구독 처리
+
+## 피처별 생성 파일 목록
+
+**Presentation 레이어** (`Projects/Presentation/Sources/{Feature}/`)
+- `{Feature}Reactor.swift` — Action, Mutation, State + `reduce()` + `mutate()`
+- `{Feature}ViewController.swift` — `bind(reactor:)`, UI setup, SnapKit layout
+
+**Domain 레이어** (`Projects/Domain/Sources/{Feature}/`)
+- `{Feature}UseCase.swift` — protocol(`{Feature}UseCase`) + 구현체(`Default{Feature}UseCase`)
+- `{Feature}Entity.swift` — 도메인 모델 (필요 시)
+
+**Data 레이어** (`Projects/Data/Sources/{Feature}/`)
+- `{Feature}Repository.swift` — Domain의 protocol impl
+- `{Feature}Target.swift` — Moya API 타겟 정의 (API 연동 필요 시)
+
+**Flow 레이어** (`Projects/Flow/Sources/`)
+- 기존 Step에 case 추가 또는 `{Feature}Flow.swift` (독립 플로우인 경우)
+
+## 입력 프로토콜
+
+- 피처 명세 (화면 기능, API 명세, 네비게이션 흐름)
+- 기존 연관 파일 경로 (있을 경우)
+- ios-reviewer로부터의 리뷰 피드백 (재작업 시)
+
+## 출력 프로토콜
+
+- 생성/수정된 파일 목록과 각 파일의 전체 코드
+- 주요 설계 결정 사항 요약
+- 코드 완성 후 ios-reviewer에게 SendMessage로 리뷰 요청
+
+## 팀 통신 프로토콜
+
+- **수신**: 오케스트레이터로부터 피처 명세, ios-reviewer로부터 리뷰 피드백
+- **발신**: 코드 완성 후 ios-reviewer에게 리뷰 요청
+- **메시지 형식**:
+  ```
+  [코드 리뷰 요청]
+  - 생성 파일: {파일 목록}
+  - 주요 결정: {아키텍처 결정 사항}
+  - 검토 포인트: {특히 확인 요청할 부분}
+  ```
+
+## 에러 핸들링
+
+- 기존 파일 패턴과 충돌 시: 기존 코드를 먼저 읽고 패턴 파악 후 일관성 유지
+- 의존성 불명확 시: 오케스트레이터에게 명확화 요청
+- 리뷰 피드백 3회 이상 같은 이슈 반복 시: 근본 원인 분석 후 접근 방식 변경 제안

--- a/.claude/agents/ios-reviewer.md
+++ b/.claude/agents/ios-reviewer.md
@@ -1,0 +1,90 @@
+---
+name: ios-reviewer
+description: JOBIS iOS 코드 검증 에이전트. ios-developer가 생성한 코드를 ReactorKit, Clean Architecture, RxFlow, Swinject 기준으로 검증하고 구체적인 수정 지침을 제공한다.
+model: opus
+---
+
+## 핵심 역할
+
+ios-developer가 생성한 코드를 프로젝트 표준에 따라 체계적으로 검증한다. 단순 버그 탐지를 넘어 아키텍처 정합성, 패턴 준수, 레이어 경계 위반을 발견하고 구체적인 수정 지침을 제공한다.
+
+## 검증 기준 (우선순위 순)
+
+### 1. 아키텍처 검증 (Critical)
+- 레이어 의존성 방향: `Presentation → Domain → Data` (역방향 import 금지)
+- UseCase: 단일 책임, Domain 모델만 반환
+- Repository protocol은 Domain에, 구현체는 Data에 위치
+- Presentation에서 Data 레이어 직접 접근 금지
+
+### 2. ReactorKit 패턴 검증 (Critical)
+- `mutate()`: 비동기/side effect 처리, `Observable<Mutation>` 반환
+- `reduce()`: 순수 함수, side effect 없음, 동기 처리만
+- `State`: 불변 struct, 변경은 반드시 `reduce()`를 통해서만
+- `Action`, `Mutation`, `State`는 Reactor 내부 enum/struct로 선언
+
+### 3. RxSwift 검증 (High)
+- `DisposeBag`: ViewController 인스턴스 변수 (`private let disposeBag = DisposeBag()`)
+- `bind(reactor:)`에서 모든 구독 처리, viewDidLoad에서 호출
+- 메모리 누수: 클로저에서 `[weak self]` 캡처 확인
+- `share()`, `replay()` 불필요한 중복 사용 여부
+
+### 4. DI/Swinject 검증 (High)
+- 모든 의존성이 initializer injection으로 주입
+- Assembly 등록 여부 (등록 누락 시 런타임 크래시)
+- 순환 의존성 없는지 확인
+
+### 5. RxFlow 검증 (High)
+- Flow: `navigate(to:)` 내 Step별 분기 처리
+- Step: 화면 의도가 명확한 이름 (e.g., `companyDetailIsRequired(id:)`)
+- Stepper: `steps.accept()` 호출 위치가 적절한지
+
+### 6. UI/Layout 검증 (Medium)
+- `setupUI()` → `setLayout()` → `bind()` 순서 준수
+- SnapKit: `snp.makeConstraints` 사용, 중복 constraints 없음
+- Then: 클로저 내 불필요한 `self` 참조 없음
+
+### 7. 네이밍/컨벤션 검증 (Medium)
+- 파일명 = 클래스명 일치
+- UseCase: `{Feature}UseCase` (protocol), `Default{Feature}UseCase` (구현체)
+- Repository: `{Feature}Repository` (protocol), `{Feature}RepositoryImpl` (구현체)
+
+## 출력 형식
+
+```
+## 검증 결과
+
+**상태**: APPROVED / NEEDS_REVISION
+
+### Critical 이슈
+- [파일명:라인] 이슈 설명 + 수정 방법
+
+### High 이슈
+- [파일명:라인] 이슈 설명 + 수정 방법
+
+### Medium 이슈
+- [파일명:라인] 이슈 설명 + 수정 방법
+
+### 제안 (선택)
+- 개선 가능한 사항 (수정 강제 아님)
+```
+
+## 팀 통신 프로토콜
+
+- **수신**: ios-developer로부터 생성된 코드와 리뷰 요청
+- **발신**:
+  - `NEEDS_REVISION`: ios-developer에게 SendMessage로 구체적 수정 지침 전달
+  - `APPROVED`: 오케스트레이터에게 완료 보고
+- **메시지 형식** (NEEDS_REVISION 시):
+  ```
+  [리뷰 피드백]
+  수정 필수:
+  - {파일명}: {구체적 수정 내용}
+  수정 권장:
+  - {파일명}: {개선 사항}
+  ```
+
+## 에러 핸들링
+
+- 코드가 불완전한 경우: 확인된 범위 내에서 검증, 불완전 부분 명시 후 리뷰 진행
+- 표준이 모호한 경우: `Projects/Presentation/Sources/` 내 기존 Reactor/ViewController 참조하여 판단
+- 같은 이슈 3회 이상 반복 시: 패턴 자체 문제로 판단하고 오케스트레이터에게 에스컬레이션

--- a/.claude/skills/ios-code-review/skill.md
+++ b/.claude/skills/ios-code-review/skill.md
@@ -1,0 +1,119 @@
+---
+name: ios-code-review
+description: JOBIS iOS 코드 검증 스킬. ios-developer가 생성한 코드를 프로젝트 표준에 따라 검증. ReactorKit, Clean Architecture, RxFlow, Swinject 기준 검증 시 반드시 사용. 코드 리뷰, 아키텍처 검증, 패턴 준수 확인 요청 시 트리거. PR 리뷰, 코드 품질 확인, 레이어 경계 위반 탐지에도 사용할 것.
+---
+
+## 검증 실행 방법
+
+검증 대상 파일을 전부 읽은 뒤 아래 체크리스트를 순서대로 적용한다. 파일을 읽지 않고 리뷰하지 않는다.
+
+## 체크리스트
+
+### [Critical] 아키텍처 경계
+
+```
+□ Presentation이 Data 레이어를 직접 import하지 않는가?
+□ Domain이 Presentation/Data를 import하지 않는가?
+□ UseCase가 ViewController/Reactor를 참조하지 않는가?
+□ Repository protocol이 Domain에 위치하는가?
+□ Repository 구현체가 Data에 위치하는가?
+```
+
+위반 시 → Critical 이슈로 보고. 아키텍처 위반은 수정 없이 통과 불가.
+
+### [Critical] ReactorKit 패턴
+
+```
+□ mutate(): Observable<Mutation> 반환, side effect(네트워크/저장/알림) 처리
+□ reduce(): 순수 함수, Observable/async 사용 없음, side effect 없음
+□ State: 값 타입(struct), 변경은 reduce()를 통해서만
+□ Action/Mutation/State: Reactor 내부에 선언
+□ initialState: 올바른 초기값 설정
+```
+
+### [High] RxSwift 메모리 관리
+
+```
+□ DisposeBag: ViewController의 인스턴스 변수 (var/let disposeBag = DisposeBag())
+□ bind(reactor:)에서 모든 구독 처리
+□ 클로저 내 [weak self] 캡처 (순환 참조 방지)
+□ share(), replay() 불필요한 중복 없음
+□ Subject(PublishSubject 등) 직접 노출 없음 (Observable로 변환 후 노출)
+```
+
+### [High] Swinject DI
+
+```
+□ 모든 의존성이 init() 파라미터로 주입 (프로퍼티 직접 설정 금지)
+□ Assembly에 등록되어 있는가? (미등록 시 런타임 크래시)
+□ 순환 의존성 없는가? (A→B→A 형태)
+□ Singleton 범위가 적절한가? (Repository/UseCase: .container, Reactor: .transient)
+```
+
+### [High] RxFlow
+
+```
+□ Step 이름이 화면 의도를 명확히 표현하는가? (e.g., companyDetailIsRequired(id:))
+□ Flow.navigate(to:)에서 모든 Step case를 처리하는가? (switch 누락 없음)
+□ FlowContributors 반환값이 올바른가? (.one/.multiple/.none)
+□ Stepper에서 steps.accept() 호출 위치가 적절한가?
+```
+
+### [Medium] UI/Layout
+
+```
+□ setupUI() → setLayout() → bind() 순서인가?
+□ SnapKit: snp.makeConstraints 사용, 중복 constraints 없음
+□ Then: 클로저 내 불필요한 self 참조 없음
+□ viewDidLoad에서 bind(reactor:) 직접 호출하지 않음 (reactor 프로퍼티 설정으로 자동 호출)
+□ Cell 재사용 준비: prepareForReuse()에서 구독 해제
+```
+
+### [Medium] 네이밍 컨벤션
+
+```
+□ 파일명 = 클래스명 일치
+□ UseCase: 프로토콜 = {Feature}UseCase, 구현체 = Default{Feature}UseCase
+□ Repository: 프로토콜 = {Feature}Repository, 구현체 = {Feature}RepositoryImpl
+□ Reactor: {Feature}Reactor
+□ ViewController: {Feature}ViewController
+□ Step case: 현재형+수동태 (e.g., listIsRequired, detailIsRequired(id:))
+```
+
+## 출력 형식
+
+검증 결과를 반드시 다음 구조로 출력한다:
+
+```
+## 검증 결과
+
+**상태**: APPROVED / NEEDS_REVISION
+
+### Critical 이슈
+(없으면 "없음")
+- [{파일명}:{라인}] {이슈 설명}
+  수정: {구체적인 수정 방법}
+
+### High 이슈
+(없으면 "없음")
+- [{파일명}:{라인}] {이슈 설명}
+  수정: {구체적인 수정 방법}
+
+### Medium 이슈
+(없으면 "없음")
+- [{파일명}:{라인}] {이슈 설명}
+  수정: {구체적인 수정 방법}
+
+### 제안 (수정 강제 아님)
+- {개선 가능한 사항}
+```
+
+## APPROVED 조건
+
+- Critical 이슈 0개
+- High 이슈 0개
+- Medium 이슈는 있어도 APPROVED 가능 (개발자 판단)
+
+## 판단 기준 모호 시
+
+`Projects/Presentation/Sources/` 내 기존 Reactor/ViewController 파일을 직접 읽어 프로젝트 실제 패턴을 기준으로 판단한다. 문서보다 코드가 우선이다.

--- a/.claude/skills/ios-feature-dev/skill.md
+++ b/.claude/skills/ios-feature-dev/skill.md
@@ -1,0 +1,279 @@
+---
+name: ios-feature-dev
+description: JOBIS iOS 피처 개발 스킬. ReactorKit + Clean Architecture + RxFlow + Swinject 패턴으로 새 화면/기능을 구현할 때 반드시 사용. 새 Reactor, ViewController, UseCase, Repository, Flow를 만들거나 기존 피처를 수정하는 모든 작업에 트리거. iOS 코드 작성, 화면 추가, API 연동, 네비게이션 구현 요청 시 이 스킬을 사용할 것.
+---
+
+## 코드 생성 전 준비
+
+기존 유사 피처 코드를 반드시 먼저 읽어라. 패턴을 직접 확인하지 않고 생성하면 불일치가 발생한다.
+
+참고할 기존 파일 위치:
+- Reactor 패턴: `Projects/Presentation/Sources/` 내 임의의 `*Reactor.swift`
+- ViewController 패턴: `Projects/Presentation/Sources/` 내 임의의 `*ViewController.swift`
+- UseCase 패턴: `Projects/Domain/Sources/` 내 임의의 `*UseCase.swift`
+- Repository 패턴: `Projects/Data/Sources/` 내 임의의 `*Repository.swift`
+- Flow/Step 패턴: `Projects/Flow/Sources/` 내 기존 파일
+
+## Reactor 작성 패턴
+
+```swift
+import ReactorKit
+import RxSwift
+
+final class {Feature}Reactor: Reactor {
+    
+    enum Action {
+        case viewDidLoad
+        case tapButton(id: String)
+    }
+    
+    enum Mutation {
+        case setLoading(Bool)
+        case setData([{Feature}Entity])
+        case setError(String)
+    }
+    
+    struct State {
+        var isLoading: Bool = false
+        var data: [{Feature}Entity] = []
+        var errorMessage: String? = nil
+    }
+    
+    let initialState = State()
+    private let {feature}UseCase: {Feature}UseCase
+    
+    init({feature}UseCase: {Feature}UseCase) {
+        self.{feature}UseCase = {feature}UseCase
+    }
+    
+    // side effect 처리 — Observable<Mutation> 반환
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .viewDidLoad:
+            return Observable.concat([
+                .just(.setLoading(true)),
+                {feature}UseCase.fetch()
+                    .map { Mutation.setData($0) }
+                    .catch { .just(.setError($0.localizedDescription)) },
+                .just(.setLoading(false))
+            ])
+        case let .tapButton(id):
+            // 네비게이션은 여기서 처리하지 않음 — ViewController에서 처리
+            return .empty()
+        }
+    }
+    
+    // 순수 함수 — side effect 없음, Observable 사용 금지
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .setLoading(isLoading):
+            newState.isLoading = isLoading
+        case let .setData(data):
+            newState.data = data
+        case let .setError(message):
+            newState.errorMessage = message
+        }
+        return newState
+    }
+}
+```
+
+## ViewController 작성 패턴
+
+```swift
+import UIKit
+import ReactorKit
+import RxSwift
+import SnapKit
+import Then
+
+final class {Feature}ViewController: UIViewController, View {
+    
+    // MARK: - UI Components
+    private let tableView = UITableView().then {
+        $0.backgroundColor = .white
+        $0.register({Feature}Cell.self, forCellReuseIdentifier: {Feature}Cell.reuseIdentifier)
+    }
+    
+    // MARK: - Properties
+    var disposeBag = DisposeBag()
+    
+    // MARK: - Init
+    init(reactor: {Feature}Reactor) {
+        super.init(nibName: nil, bundle: nil)
+        self.reactor = reactor
+    }
+    
+    required init?(coder: NSCoder) { fatalError() }
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setLayout()
+    }
+    
+    // MARK: - Setup
+    private func setupUI() {
+        view.backgroundColor = .white
+        view.addSubview(tableView)
+    }
+    
+    private func setLayout() {
+        tableView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    // MARK: - Bind
+    // bind(reactor:)는 reactor 프로퍼티 설정 시 자동 호출됨
+    func bind(reactor: {Feature}Reactor) {
+        // Action 바인딩
+        rx.viewDidLoad
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        // State 바인딩
+        reactor.state.map { $0.data }
+            .bind(to: tableView.rx.items(
+                cellIdentifier: {Feature}Cell.reuseIdentifier,
+                cellType: {Feature}Cell.self
+            )) { _, item, cell in
+                cell.configure(with: item)
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isLoading }
+            .distinctUntilChanged()
+            .bind(to: /* 로딩 인디케이터 */)
+            .disposed(by: disposeBag)
+    }
+}
+```
+
+## UseCase 작성 패턴
+
+```swift
+// Protocol은 Domain 레이어에 위치
+protocol {Feature}UseCase {
+    func fetch() -> Observable<[{Feature}Entity]>
+    func execute(id: String) -> Observable<Void>
+}
+
+// 구현체도 Domain 레이어에 위치 (Data 레이어에 두지 말 것)
+final class Default{Feature}UseCase: {Feature}UseCase {
+    
+    private let repository: {Feature}Repository
+    
+    init(repository: {Feature}Repository) {
+        self.repository = repository
+    }
+    
+    func fetch() -> Observable<[{Feature}Entity]> {
+        repository.fetch()
+    }
+}
+```
+
+## Repository 작성 패턴
+
+```swift
+// Protocol은 Domain 레이어에 위치
+protocol {Feature}Repository {
+    func fetch() -> Observable<[{Feature}Entity]>
+}
+
+// 구현체는 Data 레이어에 위치
+final class {Feature}RepositoryImpl: {Feature}Repository {
+    
+    private let dataSource: {Feature}DataSource
+    
+    init(dataSource: {Feature}DataSource) {
+        self.dataSource = dataSource
+    }
+    
+    func fetch() -> Observable<[{Feature}Entity]> {
+        dataSource.fetch()
+            .map { $0.map { $0.toDomain() } }  // DTO → Entity 변환
+    }
+}
+```
+
+## Flow/Step 패턴
+
+```swift
+// Step 정의 — 화면 의도가 명확한 이름 사용
+enum {Feature}Step: Step {
+    case {feature}IsRequired               // 피처 첫 진입
+    case {feature}DetailIsRequired(id: String)  // 상세 화면
+    case popIsRequired                     // 뒤로 가기
+}
+
+// Flow 정의
+final class {Feature}Flow: Flow {
+    var root: Presentable { rootViewController }
+    private let rootViewController = UINavigationController()
+    private let container: Container
+    
+    init(container: Container) {
+        self.container = container
+    }
+    
+    func navigate(to step: Step) -> FlowContributors {
+        guard let step = step as? {Feature}Step else { return .none }
+        switch step {
+        case .{feature}IsRequired:
+            return navigateTo{Feature}()
+        case let .{feature}DetailIsRequired(id):
+            return navigateTo{Feature}Detail(id: id)
+        case .popIsRequired:
+            rootViewController.popViewController(animated: true)
+            return .none
+        }
+    }
+    
+    private func navigateTo{Feature}() -> FlowContributors {
+        let reactor = container.resolve({Feature}Reactor.self)!
+        let vc = {Feature}ViewController(reactor: reactor)
+        rootViewController.pushViewController(vc, animated: true)
+        return .one(flowContributor: .contribute(
+            withNextPresentable: vc,
+            withNextStepper: reactor
+        ))
+    }
+}
+```
+
+## Swinject Assembly 등록
+
+```swift
+// {Feature}Assembly.swift — Data 또는 Presentation 어셈블리에 추가
+final class {Feature}Assembly: Assembly {
+    func assemble(container: Container) {
+        // Data 레이어
+        container.register({Feature}DataSource.self) { _ in
+            {Feature}DataSourceImpl()
+        }
+        container.register({Feature}Repository.self) { r in
+            {Feature}RepositoryImpl(dataSource: r.resolve({Feature}DataSource.self)!)
+        }
+        // Domain 레이어
+        container.register({Feature}UseCase.self) { r in
+            Default{Feature}UseCase(repository: r.resolve({Feature}Repository.self)!)
+        }
+        // Presentation 레이어
+        container.register({Feature}Reactor.self) { r in
+            {Feature}Reactor({feature}UseCase: r.resolve({Feature}UseCase.self)!)
+        }
+    }
+}
+```
+
+## 주의 사항
+
+- `reduce()`에서 네트워크 호출, 타이머, 알림 등 side effect를 절대 사용하지 않는다
+- `bind(reactor:)` 외부에서 `.subscribe()` 직접 호출은 최소화한다
+- `tableView.rx.modelSelected` 등의 UI 이벤트에서 직접 화면 전환하지 않고, Reactor Action으로 전달 후 State로 처리하거나 `reactor.state.map`에서 처리한다
+- 피처 간 의존성이 필요한 경우 반드시 Domain의 protocol을 통해서만 참조한다

--- a/.claude/skills/ios-harness/skill.md
+++ b/.claude/skills/ios-harness/skill.md
@@ -1,0 +1,100 @@
+---
+name: ios-harness
+description: JOBIS iOS 개발 하네스 오케스트레이터. ios-developer와 ios-reviewer 에이전트 팀을 조율하여 피처를 개발하고 검증한다. "피처 개발해줘", "화면 만들어줘", "기능 추가해줘" 등 새 기능 구현 요청 시 반드시 사용. 단순 코드 수정이 아닌 새 Reactor/ViewController/UseCase/Repository를 포함하는 작업에 트리거.
+---
+
+## 실행 모드
+
+**에이전트 팀 모드** — ios-developer와 ios-reviewer가 TeamCreate로 구성된 팀에서 직접 통신(SendMessage)하며 협업한다.
+
+## 워크플로우
+
+### Phase 1: 준비
+
+피처 명세를 확인하고 작업 범위를 정의한다.
+
+1. 사용자 요청에서 다음을 파악한다:
+   - 피처 이름 및 기능 설명
+   - 관련 API 명세 (있으면)
+   - 네비게이션 흐름
+   - 연관된 기존 모듈
+
+2. `_workspace/` 디렉토리를 생성하고 피처 명세를 파일로 저장한다:
+   ```
+   _workspace/01_spec_{feature}.md
+   ```
+
+### Phase 2: 팀 구성
+
+```
+TeamCreate(
+  team_name: "ios-feature-team",
+  members: ["ios-developer", "ios-reviewer"]
+)
+```
+
+작업 목록을 생성한다:
+```
+TaskCreate([
+  { id: "dev", title: "피처 코드 생성", assignee: "ios-developer" },
+  { id: "review", title: "코드 검증", assignee: "ios-reviewer", depends_on: ["dev"] }
+])
+```
+
+### Phase 3: 개발-검증 사이클
+
+**개발 (ios-developer):**
+- `_workspace/01_spec_{feature}.md`를 읽고 피처 명세 파악
+- 기존 유사 코드를 읽어 패턴 파악
+- 레이어 전반 코드 생성 (Reactor, VC, UseCase, Repository, Flow)
+- 생성 완료 후 ios-reviewer에게 SendMessage로 리뷰 요청
+
+**검증 (ios-reviewer):**
+- 생성된 코드를 모두 읽은 뒤 ios-code-review 체크리스트 적용
+- 결과를 `_workspace/02_review_{feature}.md`에 저장
+- `APPROVED`: 오케스트레이터에게 완료 보고
+- `NEEDS_REVISION`: ios-developer에게 SendMessage로 수정 지침 전달
+
+**반복:**
+- ios-developer가 피드백 반영 후 재검증 요청
+- 최대 3회 반복 → 3회 후에도 Critical 이슈 존재 시 오케스트레이터에게 에스컬레이션
+
+### Phase 4: 완료 및 정리
+
+- `_workspace/` 내 중간 파일 보존 (감사 추적용)
+- 최종 생성 파일 목록을 사용자에게 보고
+- 팀 정리
+
+## 데이터 전달 프로토콜
+
+| 데이터 | 전달 방식 | 경로 |
+|--------|---------|------|
+| 피처 명세 | 파일 | `_workspace/01_spec_{feature}.md` |
+| 생성 코드 | 직접 작성 | `Projects/{Layer}/Sources/{Feature}/` |
+| 리뷰 결과 | 파일 + SendMessage | `_workspace/02_review_{feature}.md` |
+| 수정 지침 | SendMessage | ios-reviewer → ios-developer |
+| 최종 보고 | 텍스트 | 사용자에게 직접 |
+
+## 에러 핸들링
+
+| 상황 | 처리 방법 |
+|------|---------|
+| 피처 명세 불완전 | 개발 시작 전 사용자에게 명확화 요청 |
+| 3회 반복 후 Critical 이슈 잔존 | 오케스트레이터가 직접 개입, 근본 원인 분석 |
+| 기존 파일과 충돌 | ios-developer가 기존 코드 읽기 후 판단, 필요시 오케스트레이터 승인 |
+| 에이전트 응답 없음 | 1회 재시도 후 실패 시 해당 Phase 건너뛰고 보고서에 명시 |
+
+## 테스트 시나리오
+
+### 정상 흐름
+1. 사용자: "북마크 목록 화면 만들어줘 (GET /bookmarks API)"
+2. 오케스트레이터가 명세 파일 작성 후 팀 구성
+3. ios-developer: BookmarkListReactor, BookmarkListViewController, BookmarkUseCase, BookmarkRepository 생성
+4. ios-reviewer: 검증 후 APPROVED
+5. 사용자에게 생성 파일 목록 보고
+
+### 에러 흐름
+1. ios-reviewer가 NEEDS_REVISION (Reactor의 reduce()에서 네트워크 호출 발견)
+2. ios-developer가 mutate()로 이동 후 재제출
+3. ios-reviewer APPROVED
+4. 완료 보고

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,10 @@ Gemfile.lock
 .claude/*
 !.claude/agents/
 !.claude/skills/
+.claude/skills/my-skill/
+
+### OMC ###
+.omc/
 
 ### Tuist build files ###
 .build/

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,9 @@ vendor/bundle/
 Gemfile.lock
 
 ### Claude ###
-.claude/
+.claude/*
+!.claude/agents/
+!.claude/skills/
 
 ### Tuist build files ###
 .build/


### PR DESCRIPTION
## 개요
Claude Code 기반 AI 에이전트 팀 하네스 초기 세팅

## 작업사항
- `ios-developer` 에이전트 정의 — ReactorKit + Clean Architecture + RxFlow 패턴으로 피처 코드 생성
- `ios-reviewer` 에이전트 정의 — 생성된 코드를 아키텍처/패턴 기준으로 검증
- `ios-harness` 스킬 — 두 에이전트를 조율하는 오케스트레이터 (생성-검증 루프)
- `ios-feature-dev` 스킬 — Reactor/VC/UseCase/Repository 코드 패턴 가이드
- `ios-code-review` 스킬 — Critical/High/Medium 기준 검증 체크리스트
- `.gitignore` — `.claude/agents/`, `.claude/skills/` 트래킹, `.omc/` 제외 처리

## UI
N/A