### PR TITLE
🔗 :: (#425) Flow rootViewController IUO 크래시 수정 및 공지사항 첨부파일 다운로드

### DIFF
--- a/Projects/Core/Sources/Steps/ApplyStep.swift
+++ b/Projects/Core/Sources/Steps/ApplyStep.swift
@@ -1,7 +1,7 @@
 import RxFlow
 
 public enum ApplyStep: Step {
-    case applyIsRequired(recruitmentId: Int, name: String, imageURL: String)
+    case applyIsRequired
     case reApplyIsRequired(applicationId: Int, name: String, imageURL: String)
     case popToRecruitmentDetail
     case errorToast(message: String)

--- a/Projects/Core/Sources/Steps/CompanyDetailStep.swift
+++ b/Projects/Core/Sources/Steps/CompanyDetailStep.swift
@@ -1,7 +1,7 @@
 import RxFlow
 
 public enum CompanyDetailStep: Step {
-    case companyDetailIsRequired(companyId: Int, type: CompanyDetailPreviousViewType)
+    case companyDetailIsRequired
     case popIsRequired
     case recruitmentDetailIsRequired(id: Int)
     case interviewReviewDetailIsRequired(

--- a/Projects/Core/Sources/Steps/InterviewAtmosphereStep.swift
+++ b/Projects/Core/Sources/Steps/InterviewAtmosphereStep.swift
@@ -1,13 +1,7 @@
 import RxFlow
 
 public enum InterviewAtmosphereStep: Step {
-    case interviewAtmosphereIsRequired(
-        companyID: Int,
-        interviewType: String,
-        location: String,
-        jobCode: Int,
-        interviewerCount: Int
-    )
+    case interviewAtmosphereIsRequired
     case navigateToWritableReview
     case popToWritableReview
     case popViewController

--- a/Projects/Core/Sources/Steps/InterviewReviewStep.swift
+++ b/Projects/Core/Sources/Steps/InterviewReviewStep.swift
@@ -1,5 +1,5 @@
 import RxFlow
 
 public enum InterviewReviewDetailStep: Step {
-    case interviewReviewDetailIsRequired(reviewId: String)
+    case interviewReviewDetailIsRequired
 }

--- a/Projects/Core/Sources/Steps/NoticeDetailStep.swift
+++ b/Projects/Core/Sources/Steps/NoticeDetailStep.swift
@@ -1,6 +1,6 @@
 import RxFlow
 
 public enum NoticeDetailStep: Step {
-    case noticeDetailIsRequired(noticeID: Int)
+    case noticeDetailIsRequired
     case noticeListIsRequired
 }

--- a/Projects/Core/Sources/Steps/RecruitmentDetailStep.swift
+++ b/Projects/Core/Sources/Steps/RecruitmentDetailStep.swift
@@ -1,7 +1,7 @@
 import RxFlow
 
 public enum RecruitmentDetailStep: Step {
-    case recruitmentDetailIsRequired(id: Int?, companyId: Int?, type: RecruitmentDetailPreviousViewType)
+    case recruitmentDetailIsRequired
     case companyDetailIsRequired(id: Int)
     case applyIsRequired(id: Int, name: String, imageURL: String)
 }

--- a/Projects/Core/Sources/Steps/RejectReasonStep.swift
+++ b/Projects/Core/Sources/Steps/RejectReasonStep.swift
@@ -1,12 +1,7 @@
 import RxFlow
 
 public enum RejectReasonStep: Step {
-    case rejectReasonIsRequired(
-        applicationID: Int,
-        recruitmentID: Int,
-        companyName: String,
-        companyImageUrl: String
-    )
+    case rejectReasonIsRequired
     case reApplyIsRequired(
         recruitmentID: Int,
         applicationID: Int,

--- a/Projects/Core/Sources/Steps/RenewalPasswordStep.swift
+++ b/Projects/Core/Sources/Steps/RenewalPasswordStep.swift
@@ -2,5 +2,5 @@ import RxFlow
 
 public enum RenewalPasswordStep: Step {
     case tabsIsRequired
-    case renewalPasswordIsRequired(email: String)
+    case renewalPasswordIsRequired
 }

--- a/Projects/Core/Sources/Steps/ReviewDetailStep.swift
+++ b/Projects/Core/Sources/Steps/ReviewDetailStep.swift
@@ -1,5 +1,5 @@
 import RxFlow
 
 public enum ReviewDetailStep: Step {
-    case reviewDetailIsRequired(reviewId: String)
+    case reviewDetailIsRequired
 }

--- a/Projects/Flow/Sources/Apply/ApplyFlow.swift
+++ b/Projects/Flow/Sources/Apply/ApplyFlow.swift
@@ -6,37 +6,38 @@ import Core
 
 public final class ApplyFlow: Flow {
     public let container: Container
-    private var rootViewController: ApplyViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: ApplyViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(
+        container: Container,
+        recruitmentId: Int? = nil,
+        applicationId: Int? = nil,
+        companyName: String,
+        companyImageURL: String,
+        applyType: ApplyType
+    ) {
         self.container = container
+        self.rootViewController = container.resolve(
+            ApplyViewController.self,
+            arguments: recruitmentId, applicationId, companyName, companyImageURL, applyType
+        )!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? ApplyStep else { return .none }
 
         switch step {
-        case let .applyIsRequired(recruitmentId, name, imageURL):
-            return navigateToApply(
-                recruitmentId: recruitmentId,
-                applicationId: nil,
-                name: name,
-                imageURL: imageURL,
-                applyType: .apply
-            )
-
-        case let .reApplyIsRequired(applicationId, name, imageURL):
-            return navigateToApply(
-                recruitmentId: nil,
-                applicationId: applicationId,
-                name: name,
-                imageURL: imageURL,
-                applyType: .reApply
-            )
+        case let .applyIsRequired(id, name, imageURL):
+            return navigateToApply(id: id, name: name, imageURL: imageURL)
 
         case .popToRecruitmentDetail:
             return popToRecruitmentDetail()
+
+        case let .reApplyIsRequired(id, name, imageURL):
+            return navigateToReApply(id: id, name: name, imageURL: imageURL)
 
         case let .errorToast(message):
             return errorToast(message: message)
@@ -45,17 +46,14 @@ public final class ApplyFlow: Flow {
 }
 
 private extension ApplyFlow {
-    func navigateToApply(
-        recruitmentId: Int?,
-        applicationId: Int?,
-        name: String,
-        imageURL: String,
-        applyType: ApplyType
-    ) -> FlowContributors {
-        rootViewController = container.resolve(
-            ApplyViewController.self,
-            arguments: recruitmentId, applicationId, name, imageURL, applyType
-        )!
+    func navigateToApply(id: Int, name: String, imageURL: String) -> FlowContributors {
+        return .one(flowContributor: .contribute(
+            withNextPresentable: rootViewController,
+            withNextStepper: rootViewController.reactor
+        ))
+    }
+
+    func navigateToReApply(id: Int, name: String, imageURL: String) -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Apply/ApplyFlow.swift
+++ b/Projects/Flow/Sources/Apply/ApplyFlow.swift
@@ -30,8 +30,8 @@ public final class ApplyFlow: Flow {
         guard let step = step as? ApplyStep else { return .none }
 
         switch step {
-        case let .applyIsRequired(id, name, imageURL):
-            return navigateToApply(id: id, name: name, imageURL: imageURL)
+        case .applyIsRequired:
+            return navigateToApply()
 
         case .popToRecruitmentDetail:
             return popToRecruitmentDetail()
@@ -46,7 +46,7 @@ public final class ApplyFlow: Flow {
 }
 
 private extension ApplyFlow {
-    func navigateToApply(id: Int, name: String, imageURL: String) -> FlowContributors {
+    func navigateToApply() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Bookmark/BookmarkFlow.swift
+++ b/Projects/Flow/Sources/Bookmark/BookmarkFlow.swift
@@ -43,7 +43,10 @@ private extension BookmarkFlow {
     }
 
     func navigateToRecruitmentDetail(_ recruitmentID: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -54,13 +57,7 @@ private extension BookmarkFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 }

--- a/Projects/Flow/Sources/ChangePassword/ChangePasswordFlow.swift
+++ b/Projects/Flow/Sources/ChangePassword/ChangePasswordFlow.swift
@@ -6,13 +6,17 @@ import Core
 
 public final class ChangePasswordFlow: Flow {
     public let container: Container
-    private var rootViewController: ChangePasswordViewController!
+    private let rootViewController: ChangePasswordViewController
     public var root: Presentable {
-        return rootViewController!
+        return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, currentPassword: String = "") {
         self.container = container
+        self.rootViewController = container.resolve(
+            ChangePasswordViewController.self,
+            argument: currentPassword
+        )!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -30,8 +34,6 @@ public final class ChangePasswordFlow: Flow {
 
 private extension ChangePasswordFlow {
     func navigateToChangePassword(currentPassword: String) -> FlowContributors {
-        rootViewController = container.resolve(ChangePasswordViewController.self, argument: currentPassword)!
-
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/ChangePassword/ConfirmPasswordFlow.swift
+++ b/Projects/Flow/Sources/ChangePassword/ConfirmPasswordFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class ConfirmPasswordFlow: Flow {
     public let container: Container
-    private var rootViewController: ConfirmPasswordViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: ConfirmPasswordViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = ConfirmPasswordViewController(container.resolve(ConfirmPasswordReactor.self)!)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class ConfirmPasswordFlow: Flow {
 
 private extension ConfirmPasswordFlow {
     func navigateToConfirmPassword() -> FlowContributors {
-        rootViewController = container.resolve(ConfirmPasswordViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -38,7 +40,7 @@ private extension ConfirmPasswordFlow {
     func navigateToChangePassword(
         currentPassword: String
     ) -> FlowContributors {
-        let changePasswordFlow = ChangePasswordFlow(container: container)
+        let changePasswordFlow = ChangePasswordFlow(container: container, currentPassword: currentPassword)
 
         Flows.use(changePasswordFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/Company/CompanyDetailFlow.swift
+++ b/Projects/Flow/Sources/Company/CompanyDetailFlow.swift
@@ -6,25 +6,32 @@ import Core
 
 public final class CompanyDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: CompanyDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: CompanyDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(
+        container: Container,
+        companyId: Int,
+        type: CompanyDetailPreviousViewType = .recruitmentDetail
+    ) {
         self.container = container
+        self.rootViewController = container.resolve(CompanyDetailViewController.self, arguments: companyId, type)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? CompanyDetailStep else { return .none }
 
         switch step {
-        case let .companyDetailIsRequired(companyId, type):
-            return navigateToCompanyDetail(companyId: companyId, type: type)
+        case .companyDetailIsRequired:
+            return navigateToCompanyDetail()
 
         case .popIsRequired:
             return popCompanyDetail()
 
-        case let .recruitmentDetailIsRequired(id):
-            return navigateToRecruitmentDetail(recruitmentID: id)
+        case let.recruitmentDetailIsRequired(id):
+            return navigateToRecruimtentDetail(recruitmentID: id)
 
         case let .interviewReviewDetailIsRequired(id, name):
             return navigateToInterviewReviewDetail(id, name)
@@ -33,14 +40,7 @@ public final class CompanyDetailFlow: Flow {
 }
 
 private extension CompanyDetailFlow {
-    func navigateToCompanyDetail(
-        companyId: Int,
-        type: CompanyDetailPreviousViewType
-    ) -> FlowContributors {
-        rootViewController = container.resolve(
-            CompanyDetailViewController.self,
-            arguments: companyId, type
-        )!
+    func navigateToCompanyDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -52,8 +52,12 @@ private extension CompanyDetailFlow {
         return .none
     }
 
-    func navigateToRecruitmentDetail(recruitmentID: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+    func navigateToRecruimtentDetail(recruitmentID: Int) -> FlowContributors {
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID,
+            type: .companyDetail
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -64,18 +68,15 @@ private extension CompanyDetailFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .companyDetail
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 
     func navigateToInterviewReviewDetail(_ id: Int, _ name: String) -> FlowContributors {
-        let interviewReviewDetailFlow = InterviewReviewDetailFlow(container: container)
+        let interviewReviewDetailFlow = InterviewReviewDetailFlow(
+            container: container,
+            reviewId: String(id)
+        )
 
         Flows.use(interviewReviewDetailFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(
@@ -86,11 +87,7 @@ private extension CompanyDetailFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: interviewReviewDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: InterviewReviewDetailStep.interviewReviewDetailIsRequired(
-                    reviewId: String(id)
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: InterviewReviewDetailStep.interviewReviewDetailIsRequired)
         ))
     }
 }

--- a/Projects/Flow/Sources/Company/CompanyFlow.swift
+++ b/Projects/Flow/Sources/Company/CompanyFlow.swift
@@ -40,7 +40,11 @@ private extension CompanyFlow {
     }
 
     func navigateToCompanyDetail(_ id: Int) -> FlowContributors {
-        let companyDetailFlow = CompanyDetailFlow(container: container)
+        let companyDetailFlow = CompanyDetailFlow(
+            container: container,
+            companyId: id,
+            type: .searchCompany
+        )
 
         Flows.use(companyDetailFlow, when: .created) { (root) in
             self.rootViewController.pushViewController(
@@ -50,12 +54,7 @@ private extension CompanyFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: companyDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: CompanyDetailStep.companyDetailIsRequired(
-                    companyId: id,
-                    type: .searchCompany
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: CompanyDetailStep.companyDetailIsRequired)
         ))
     }
 

--- a/Projects/Flow/Sources/Company/InterviewReviewFlow.swift
+++ b/Projects/Flow/Sources/Company/InterviewReviewFlow.swift
@@ -6,29 +6,28 @@ import Core
 
 public final class InterviewReviewDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: InterviewReviewDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: InterviewReviewDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(container: Container, reviewId: String) {
         self.container = container
+        self.rootViewController = container.resolve(InterviewReviewDetailViewController.self, argument: reviewId)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? InterviewReviewDetailStep else { return .none }
 
         switch step {
-        case let .interviewReviewDetailIsRequired(reviewId):
-            return navigateToInterviewReviewDetail(reviewId: reviewId)
+        case .interviewReviewDetailIsRequired:
+            return navigateToInterviewReviewDetail()
         }
     }
 }
 
 private extension InterviewReviewDetailFlow {
-    func navigateToInterviewReviewDetail(reviewId: String) -> FlowContributors {
-        rootViewController = container.resolve(
-            InterviewReviewDetailViewController.self,
-            argument: reviewId
-        )!
+    func navigateToInterviewReviewDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Company/SearchCompanyFlow.swift
+++ b/Projects/Flow/Sources/Company/SearchCompanyFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class SearchCompanyFlow: Flow {
     public let container: Container
-    private var rootViewController: SearchCompanyViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: SearchCompanyViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(SearchCompanyViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class SearchCompanyFlow: Flow {
 
 private extension SearchCompanyFlow {
     func navigateToSearchCompany() -> FlowContributors {
-        rootViewController = container.resolve(SearchCompanyViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -36,7 +38,11 @@ private extension SearchCompanyFlow {
     }
 
     func navigateToCompanyDetail(_ companyId: Int) -> FlowContributors {
-        let companyDetailFlow = CompanyDetailFlow(container: container)
+        let companyDetailFlow = CompanyDetailFlow(
+            container: container,
+            companyId: companyId,
+            type: .searchCompany
+        )
 
         Flows.use(companyDetailFlow, when: .created) { (root) in
             self.rootViewController.navigationController?.pushViewController(
@@ -46,12 +52,7 @@ private extension SearchCompanyFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: companyDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: CompanyDetailStep.companyDetailIsRequired(
-                    companyId: companyId,
-                    type: .searchCompany
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: CompanyDetailStep.companyDetailIsRequired)
         ))
     }
 }

--- a/Projects/Flow/Sources/Home/AlarmFlow.swift
+++ b/Projects/Flow/Sources/Home/AlarmFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class AlarmFlow: Flow {
     public let container: Container
-    private var rootViewController: AlarmViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: AlarmViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(AlarmViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -25,7 +28,6 @@ public final class AlarmFlow: Flow {
 
 private extension AlarmFlow {
     func navigateToAlarm() -> FlowContributors {
-        rootViewController = container.resolve(AlarmViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Home/EasterEggFlow.swift
+++ b/Projects/Flow/Sources/Home/EasterEggFlow.swift
@@ -7,11 +7,14 @@ import Core
 
 public final class EasterEggFlow: Flow {
     public let container: Container
-    private var rootViewController: EasterEggViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: RxFlowViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(EasterEggViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -26,7 +29,6 @@ public final class EasterEggFlow: Flow {
 
 private extension EasterEggFlow {
     func navigateToEasterEgg() -> FlowContributors {
-        rootViewController = container.resolve(EasterEggViewController.self)!
         return .one(flowContributor: .contribute(withNext: rootViewController))
     }
 }

--- a/Projects/Flow/Sources/Home/EmployStatusFlow.swift
+++ b/Projects/Flow/Sources/Home/EmployStatusFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class EmployStatusFlow: Flow {
     public let container: Container
-    private var rootViewController: EmployStatusViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: EmployStatusViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(EmployStatusViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -34,7 +37,6 @@ public final class EmployStatusFlow: Flow {
 
 private extension EmployStatusFlow {
     func navigateToEmployStatus() -> FlowContributors {
-        rootViewController = container.resolve(EmployStatusViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Home/HomeFlow.swift
+++ b/Projects/Flow/Sources/Home/HomeFlow.swift
@@ -136,7 +136,13 @@ private extension HomeFlow {
         _ companyName: String,
         _ companyImageUrl: String
     ) -> FlowContributors {
-        let rejectReasonFlow = RejectReasonFlow(container: container)
+        let rejectReasonFlow = RejectReasonFlow(
+            container: container,
+            applicationID: applicationID,
+            recruitmentID: recruitmentID,
+            companyName: companyName,
+            companyImageUrl: companyImageUrl
+        )
         Flows.use(rejectReasonFlow, when: .created) { root in
             self.rootViewController.present(
                 root,
@@ -147,12 +153,7 @@ private extension HomeFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: rejectReasonFlow,
             withNextStepper: OneStepper(
-                withSingleStep: RejectReasonStep.rejectReasonIsRequired(
-                    applicationID: applicationID,
-                    recruitmentID: recruitmentID,
-                    companyName: companyName,
-                    companyImageUrl: companyImageUrl
-                )
+                withSingleStep: RejectReasonStep.rejectReasonIsRequired
             )
         ))
     }
@@ -163,7 +164,14 @@ private extension HomeFlow {
         _ companyName: String,
         _ companyImageUrl: String
     ) -> FlowContributors {
-        let applyFlow = ApplyFlow(container: container)
+        let applyFlow = ApplyFlow(
+            container: container,
+            recruitmentId: recruitmentID,
+            applicationId: applicationID,
+            companyName: companyName,
+            companyImageURL: companyImageUrl,
+            applyType: .reApply
+        )
         Flows.use(applyFlow, when: .created) { root in
             self.rootViewController.pushViewController(
                 root,
@@ -184,7 +192,10 @@ private extension HomeFlow {
     }
 
     func navigateToRecruitmentDetail(_ recruitmentID: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -199,13 +210,7 @@ private extension HomeFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 

--- a/Projects/Flow/Sources/MyPage/BugReport/BugReportFlow.swift
+++ b/Projects/Flow/Sources/MyPage/BugReport/BugReportFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class BugReportFlow: Flow {
     public let container: Container
-    private var rootViewController: BugReportViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: BugReportViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(BugReportViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class BugReportFlow: Flow {
 
 private extension BugReportFlow {
     func navigateToBugReport() -> FlowContributors {
-        rootViewController = container.resolve(BugReportViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/MyPage/BugReport/MajorBottomSheetFlow.swift
+++ b/Projects/Flow/Sources/MyPage/BugReport/MajorBottomSheetFlow.swift
@@ -6,11 +6,17 @@ import Core
 
 public final class MajorBottomSheetFlow: Flow {
     public let container: Container
-    private var rootViewController: MajorBottomSheetViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: MajorBottomSheetViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = MajorBottomSheetViewController(
+            container.resolve(MajorBottomSheetViewModel.self)!,
+            state: .custom(height: 300)
+        )
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +34,6 @@ public final class MajorBottomSheetFlow: Flow {
 
 private extension MajorBottomSheetFlow {
     func navigateToMajorBottomSheet() -> FlowContributors {
-        rootViewController = container.resolve(MajorBottomSheetViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.viewModel

--- a/Projects/Flow/Sources/MyPage/InterestField/InterestFieldCheckFlow.swift
+++ b/Projects/Flow/Sources/MyPage/InterestField/InterestFieldCheckFlow.swift
@@ -6,11 +6,15 @@ import Core
 
 public final class InterestFieldCheckFlow: Flow {
     public let container: Container
-    private var rootViewController: InterestFieldCheckViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: InterestFieldCheckViewController
+
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(InterestFieldCheckViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -31,7 +35,6 @@ public final class InterestFieldCheckFlow: Flow {
 
 private extension InterestFieldCheckFlow {
     func navigateToInterestField() -> FlowContributors {
-        rootViewController = container.resolve(InterestFieldCheckViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/MyPage/InterestField/InterestFieldFlow.swift
+++ b/Projects/Flow/Sources/MyPage/InterestField/InterestFieldFlow.swift
@@ -6,11 +6,15 @@ import Core
 
 public final class InterestFieldFlow: Flow {
     public let container: Container
-    private var rootViewController: InterestFieldViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: InterestFieldViewController
+
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(InterestFieldViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -36,7 +40,6 @@ public final class InterestFieldFlow: Flow {
 
 private extension InterestFieldFlow {
     func navigateToInterestField() -> FlowContributors {
-        rootViewController = container.resolve(InterestFieldViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/MyPage/MyPageFlow.swift
+++ b/Projects/Flow/Sources/MyPage/MyPageFlow.swift
@@ -176,7 +176,10 @@ extension MyPageFlow {
     }
 
     func navigateToRecruitmentDetail(_ recruitmentID: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -187,13 +190,7 @@ extension MyPageFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 

--- a/Projects/Flow/Sources/MyPage/Notice/NoticeDetailFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Notice/NoticeDetailFlow.swift
@@ -6,19 +6,22 @@ import Core
 
 public final class NoticeDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: NoticeDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: NoticeDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(container: Container, noticeID: Int) {
         self.container = container
+        self.rootViewController = container.resolve(NoticeDetailViewController.self, argument: noticeID)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? NoticeDetailStep else { return .none }
 
         switch step {
-        case let .noticeDetailIsRequired(noticeID):
-            return navigateToNoticeDetail(noticeID: noticeID)
+        case .noticeDetailIsRequired:
+            return navigateToNoticeDetail()
         case .noticeListIsRequired:
             return popNoticeList()
         }
@@ -26,8 +29,7 @@ public final class NoticeDetailFlow: Flow {
 }
 
 private extension NoticeDetailFlow {
-    func navigateToNoticeDetail(noticeID: Int) -> FlowContributors {
-        rootViewController = container.resolve(NoticeDetailViewController.self, argument: noticeID)!
+    func navigateToNoticeDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/MyPage/Notice/NoticeFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Notice/NoticeFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class NoticeFlow: Flow {
     public let container: Container
-    private var rootViewController: NoticeViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: NoticeViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(NoticeViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class NoticeFlow: Flow {
 
 private extension NoticeFlow {
     func navigateToNotice() -> FlowContributors {
-        rootViewController = container.resolve(NoticeViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -36,7 +38,7 @@ private extension NoticeFlow {
     }
 
     func navigateToNoticeDetail(_ id: Int) -> FlowContributors {
-        let noticeDetailFlow = NoticeDetailFlow(container: container)
+        let noticeDetailFlow = NoticeDetailFlow(container: container, noticeID: id)
 
         Flows.use(noticeDetailFlow, when: .created) { (root) in
             let view = root as? NoticeDetailViewController
@@ -47,7 +49,7 @@ private extension NoticeFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: noticeDetailFlow,
-            withNextStepper: OneStepper(withSingleStep: NoticeDetailStep.noticeDetailIsRequired(noticeID: id))
+            withNextStepper: OneStepper(withSingleStep: NoticeDetailStep.noticeDetailIsRequired)
         ))
     }
 }

--- a/Projects/Flow/Sources/MyPage/Notification/NotificationSettingFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Notification/NotificationSettingFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class NotificationSettingFlow: Flow {
     public let container: Container
-    private var rootViewController: NotificationSettingViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: NotificationSettingViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(NotificationSettingViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -25,7 +28,6 @@ public final class NotificationSettingFlow: Flow {
 
 private extension NotificationSettingFlow {
     func navigateToNotificationSetting() -> FlowContributors {
-        rootViewController = container.resolve(NotificationSettingViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/MyPage/Review/AddQuestionFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Review/AddQuestionFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class AddQuestionFlow: Flow {
     public let container: Container
-    private var rootViewController: AddQuestionViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: AddQuestionViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(AddQuestionViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -31,7 +34,6 @@ public final class AddQuestionFlow: Flow {
 
 private extension AddQuestionFlow {
     func navigateToAddQuestion() -> FlowContributors {
-        rootViewController = container.resolve(AddQuestionViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.viewModel

--- a/Projects/Flow/Sources/MyPage/Review/AddReviewFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Review/AddReviewFlow.swift
@@ -6,11 +6,17 @@ import Core
 
 public final class AddReviewFlow: Flow {
     public let container: Container
-    private var rootViewController: AddReviewViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: AddReviewViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = AddReviewViewController(
+            container.resolve(AddReviewViewModel.self)!,
+            state: .custom(height: 500)
+        )
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -31,7 +37,6 @@ public final class AddReviewFlow: Flow {
 
 private extension AddReviewFlow {
     func navigateToAddReview() -> FlowContributors {
-        rootViewController = container.resolve(AddReviewViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.viewModel

--- a/Projects/Flow/Sources/MyPage/Review/InterviewAtmosphereFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Review/InterviewAtmosphereFlow.swift
@@ -7,17 +7,32 @@ import Domain
 
 public final class InterviewAtmosphereFlow: Flow {
     public let container: Container
-    private var rootViewController: InterviewAtmosphereViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: InterviewAtmosphereViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    private var companyID: Int = 0
-    private var interviewType: InterviewFormat = .individual
-    private var location: LocationType = .seoul
-    private var jobCode: Int = 0
-    private var interviewerCount: Int = 0
+    private let companyID: Int
+    private let interviewType: InterviewFormat
+    private let location: LocationType
+    private let jobCode: Int
+    private let interviewerCount: Int
 
-    public init(container: Container) {
+    public init(
+        container: Container,
+        companyID: Int,
+        interviewType: InterviewFormat,
+        location: LocationType,
+        jobCode: Int,
+        interviewerCount: Int
+    ) {
         self.container = container
+        self.rootViewController = container.resolve(InterviewAtmosphereViewController.self)!
+        self.companyID = companyID
+        self.interviewType = interviewType
+        self.location = location
+        self.jobCode = jobCode
+        self.interviewerCount = interviewerCount
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -33,14 +48,8 @@ public final class InterviewAtmosphereFlow: Flow {
         guard let step = step as? InterviewAtmosphereStep else { return .none }
 
         switch step {
-        case let .interviewAtmosphereIsRequired(companyID, interviewType, location, jobCode, interviewerCount):
-            return navigateToInterviewAtmosphere(
-                companyID: companyID,
-                interviewType: interviewType,
-                location: location,
-                jobCode: jobCode,
-                interviewerCount: interviewerCount
-            )
+        case .interviewAtmosphereIsRequired:
+            return navigateToInterviewAtmosphere()
 
         case let .addQuestionIsRequired(qnas):
             return navigateToAddQuestion(qnas: qnas as? [QnaRequestQuery] ?? [])
@@ -58,19 +67,7 @@ public final class InterviewAtmosphereFlow: Flow {
 }
 
 private extension InterviewAtmosphereFlow {
-    func navigateToInterviewAtmosphere(
-        companyID: Int,
-        interviewType: String,
-        location: String,
-        jobCode: Int,
-        interviewerCount: Int
-    ) -> FlowContributors {
-        self.companyID = companyID
-        self.interviewType = InterviewFormat(rawValue: interviewType) ?? .individual
-        self.location = LocationType(rawValue: location) ?? .daejeon
-        self.jobCode = jobCode
-        self.interviewerCount = interviewerCount
-        rootViewController = container.resolve(InterviewAtmosphereViewController.self)!
+    func navigateToInterviewAtmosphere() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.viewModel

--- a/Projects/Flow/Sources/MyPage/Review/WritableReviewFlow.swift
+++ b/Projects/Flow/Sources/MyPage/Review/WritableReviewFlow.swift
@@ -7,11 +7,14 @@ import Domain
 
 public final class WritableReviewFlow: Flow {
     public let container: Container
-    private var rootViewController: WritableReviewViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: WritableReviewViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(WritableReviewViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -38,7 +41,6 @@ public final class WritableReviewFlow: Flow {
 
 private extension WritableReviewFlow {
     func navigateToWritableReview() -> FlowContributors {
-        rootViewController = container.resolve(WritableReviewViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -73,10 +75,18 @@ private extension WritableReviewFlow {
     }
 
     func navigateToInterviewAtmosphere() -> FlowContributors {
-        let interviewAtmosphereFlow = InterviewAtmosphereFlow(container: container)
+        let interviewAtmosphereFlow = InterviewAtmosphereFlow(
+            container: container,
+            companyID: rootViewController.reactor.companyID,
+            interviewType: rootViewController.reactor.interviewType,
+            location: rootViewController.reactor.location,
+            jobCode: rootViewController.reactor.jobCode,
+            interviewerCount: rootViewController.reactor.interviewerCount
+        )
         Flows.use(interviewAtmosphereFlow, when: .created) { root in
+            guard let viewController = root as? UIViewController else { return }
             self.rootViewController.navigationController?.pushViewController(
-                root,
+                viewController,
                 animated: true
             )
         }
@@ -84,13 +94,7 @@ private extension WritableReviewFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: interviewAtmosphereFlow,
             withNextStepper: OneStepper(
-                withSingleStep: InterviewAtmosphereStep.interviewAtmosphereIsRequired(
-                    companyID: rootViewController.reactor.companyID,
-                    interviewType: rootViewController.reactor.interviewType.rawValue,
-                    location: rootViewController.reactor.location.rawValue,
-                    jobCode: rootViewController.reactor.jobCode,
-                    interviewerCount: rootViewController.reactor.interviewerCount
-                )
+                withSingleStep: InterviewAtmosphereStep.interviewAtmosphereIsRequired
             )
         ))
     }

--- a/Projects/Flow/Sources/Recruitment/RecruitmentDetailFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentDetailFlow.swift
@@ -6,19 +6,30 @@ import Core
 
 public final class RecruitmentDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: RecruitmentDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: RecruitmentDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(
+        container: Container,
+        recruitmentID: Int? = nil,
+        companyId: Int? = nil,
+        type: RecruitmentDetailPreviousViewType = .recruitmentList
+    ) {
         self.container = container
+        self.rootViewController = container.resolve(
+            RecruitmentDetailViewController.self,
+            arguments: recruitmentID, companyId, type
+        )!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? RecruitmentDetailStep else { return .none }
 
         switch step {
-        case let .recruitmentDetailIsRequired(id, companyId, type):
-            return navigateToRecruitmentDetail(id: id, companyId: companyId, type: type)
+        case .recruitmentDetailIsRequired:
+            return navigateToRecruitmentDetail()
 
         case let .companyDetailIsRequired(id):
             return navigateToCompanyDetail(id)
@@ -30,15 +41,7 @@ public final class RecruitmentDetailFlow: Flow {
 }
 
 private extension RecruitmentDetailFlow {
-    func navigateToRecruitmentDetail(
-        id: Int?,
-        companyId: Int?,
-        type: RecruitmentDetailPreviousViewType
-    ) -> FlowContributors {
-        rootViewController = container.resolve(
-            RecruitmentDetailViewController.self,
-            arguments: id, companyId, type
-        )!
+    func navigateToRecruitmentDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -46,7 +49,11 @@ private extension RecruitmentDetailFlow {
     }
 
     func navigateToCompanyDetail(_ companyDetailId: Int) -> FlowContributors {
-        let companyDetailFlow = CompanyDetailFlow(container: container)
+        let companyDetailFlow = CompanyDetailFlow(
+            container: container,
+            companyId: companyDetailId,
+            type: .recruitmentDetail
+        )
 
         Flows.use(companyDetailFlow, when: .created) { (root) in
             self.rootViewController.navigationController?.pushViewController(
@@ -57,16 +64,20 @@ private extension RecruitmentDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: companyDetailFlow,
             withNextStepper: OneStepper(
-                withSingleStep: CompanyDetailStep.companyDetailIsRequired(
-                    companyId: companyDetailId,
-                    type: .recruitmentDetail
-                )
+                withSingleStep: CompanyDetailStep.companyDetailIsRequired
             )
         ))
     }
 
     func navigateToApply(id: Int, name: String, imageURL: String) -> FlowContributors {
-        let applyFlow = ApplyFlow(container: container)
+        let applyFlow = ApplyFlow(
+            container: container,
+            recruitmentId: id,
+            applicationId: nil,
+            companyName: name,
+            companyImageURL: imageURL,
+            applyType: .apply
+        )
 
         Flows.use(applyFlow, when: .created) { (root) in
             self.rootViewController.navigationController?.pushViewController(
@@ -78,11 +89,7 @@ private extension RecruitmentDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: applyFlow,
             withNextStepper: OneStepper(
-                withSingleStep: ApplyStep.applyIsRequired(
-                    recruitmentId: id,
-                    name: name,
-                    imageURL: imageURL
-                )
+                withSingleStep: ApplyStep.applyIsRequired(recruitmentId: id, name: name, imageURL: imageURL)
             )
         ))
     }

--- a/Projects/Flow/Sources/Recruitment/RecruitmentDetailFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentDetailFlow.swift
@@ -89,7 +89,7 @@ private extension RecruitmentDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: applyFlow,
             withNextStepper: OneStepper(
-                withSingleStep: ApplyStep.applyIsRequired(recruitmentId: id, name: name, imageURL: imageURL)
+                withSingleStep: ApplyStep.applyIsRequired
             )
         ))
     }

--- a/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentFilterFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class RecruitmentFilterFlow: Flow {
     public let container: Container
-    private var rootViewController: RecruitmentFilterViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: RecruitmentFilterViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(RecruitmentFilterViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class RecruitmentFilterFlow: Flow {
 
 private extension RecruitmentFilterFlow {
     func navigateToRecruitmentFilter() -> FlowContributors {
-        rootViewController = container.resolve(RecruitmentFilterViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Recruitment/RecruitmentFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/RecruitmentFlow.swift
@@ -53,7 +53,10 @@ private extension RecruitmentFlow {
     }
 
     func navigateToRecruitmentDetail(recruitmentID: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -70,13 +73,7 @@ private extension RecruitmentFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 

--- a/Projects/Flow/Sources/Recruitment/SearchRecruitmentFlow.swift
+++ b/Projects/Flow/Sources/Recruitment/SearchRecruitmentFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class SearchRecruitmentFlow: Flow {
     public let container: Container
-    private var rootViewController: SearchRecruitmentViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: SearchRecruitmentViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(SearchRecruitmentViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class SearchRecruitmentFlow: Flow {
 
 private extension SearchRecruitmentFlow {
     func navigateToSearchRecruitment() -> FlowContributors {
-        rootViewController = container.resolve(SearchRecruitmentViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -36,7 +38,10 @@ private extension SearchRecruitmentFlow {
     }
 
     func navigateToRecruitmentDetail(_ recruitmentId: Int) -> FlowContributors {
-        let recruitmentDetailFlow = RecruitmentDetailFlow(container: container)
+        let recruitmentDetailFlow = RecruitmentDetailFlow(
+            container: container,
+            recruitmentID: recruitmentId
+        )
 
         Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? RecruitmentDetailViewController
@@ -47,13 +52,7 @@ private extension SearchRecruitmentFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: recruitmentDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentId,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 }

--- a/Projects/Flow/Sources/RejectReason/RejectReasonFlow.swift
+++ b/Projects/Flow/Sources/RejectReason/RejectReasonFlow.swift
@@ -6,26 +6,31 @@ import Core
 
 public final class RejectReasonFlow: Flow {
     public let container: Container
-    private var rootViewController: RejectReasonViewController!
+    private let rootViewController: RejectReasonViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(
+        container: Container,
+        applicationID: Int,
+        recruitmentID: Int,
+        companyName: String,
+        companyImageUrl: String
+    ) {
         self.container = container
+        self.rootViewController = container.resolve(
+            RejectReasonViewController.self,
+            arguments: applicationID, recruitmentID, companyName, companyImageUrl
+        )!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? RejectReasonStep else { return .none }
 
         switch step {
-        case let .rejectReasonIsRequired(applicationID, recruitmentID, companyName, companyImageUrl):
-            return navigateToRejectReason(
-                applicationID: applicationID,
-                recruitmentID: recruitmentID,
-                companyName: companyName,
-                companyImageUrl: companyImageUrl
-            )
+        case .rejectReasonIsRequired:
+            return navigateToRejectReason()
         case let .reApplyIsRequired(recruitmentID, applicationID, companyName, companyImageUrl):
             return navigateToReApply(recruitmentID, applicationID, companyName, companyImageUrl)
         }
@@ -33,17 +38,7 @@ public final class RejectReasonFlow: Flow {
 }
 
 private extension RejectReasonFlow {
-    func navigateToRejectReason(
-        applicationID: Int,
-        recruitmentID: Int,
-        companyName: String,
-        companyImageUrl: String
-    ) -> FlowContributors {
-        rootViewController = container.resolve(
-            RejectReasonViewController.self,
-            arguments: applicationID, recruitmentID, companyName, companyImageUrl
-        )!
-
+    func navigateToRejectReason() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/RenewalPassword/ConfirmEmailFlow.swift
+++ b/Projects/Flow/Sources/RenewalPassword/ConfirmEmailFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class ConfirmEmailFlow: Flow {
     public let container: Container
-    private var rootViewController: ConfirmEmailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: ConfirmEmailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = ConfirmEmailViewController(container.resolve(ConfirmEmailReactor.self)!)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class ConfirmEmailFlow: Flow {
 
 private extension ConfirmEmailFlow {
     func navigateToConfirmEmail() -> FlowContributors {
-        rootViewController = container.resolve(ConfirmEmailViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -38,7 +40,7 @@ private extension ConfirmEmailFlow {
     func navigateToRenewalPassword(
         email: String
     ) -> FlowContributors {
-        let renewalPasswordFlow = RenewalPasswordFlow(container: container)
+        let renewalPasswordFlow = RenewalPasswordFlow(container: container, email: email)
 
         Flows.use(renewalPasswordFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(
@@ -50,7 +52,7 @@ private extension ConfirmEmailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: renewalPasswordFlow,
             withNextStepper: OneStepper(
-                withSingleStep: RenewalPasswordStep.renewalPasswordIsRequired(email: email)
+                withSingleStep: RenewalPasswordStep.renewalPasswordIsRequired
             )
         ))
     }

--- a/Projects/Flow/Sources/RenewalPassword/RenewalPasswordFlow.swift
+++ b/Projects/Flow/Sources/RenewalPassword/RenewalPasswordFlow.swift
@@ -6,21 +6,23 @@ import Core
 
 public final class RenewalPasswordFlow: Flow {
     public let container: Container
-    private var rootViewController: RenewalPasswordViewController!
+    private let rootViewController: RenewalPasswordViewController
     public var root: Presentable {
-        return rootViewController!
+        return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, email: String) {
         self.container = container
+        let reactor = container.resolve(RenewalPasswordReactor.self, argument: email)!
+        self.rootViewController = RenewalPasswordViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? RenewalPasswordStep else { return .none }
 
         switch step {
-        case let .renewalPasswordIsRequired(email):
-            return navigateToRenewalPassword(email: email)
+        case .renewalPasswordIsRequired:
+            return navigateToRenewalPassword()
 
         case .tabsIsRequired:
             return navigateToTab()
@@ -29,10 +31,7 @@ public final class RenewalPasswordFlow: Flow {
 }
 
 private extension RenewalPasswordFlow {
-    func navigateToRenewalPassword(email: String) -> FlowContributors {
-        let reactor = container.resolve(RenewalPasswordReactor.self, argument: email)!
-        rootViewController = RenewalPasswordViewController(reactor)
-
+    func navigateToRenewalPassword() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Review/ReviewDetailFlow.swift
+++ b/Projects/Flow/Sources/Review/ReviewDetailFlow.swift
@@ -6,26 +6,28 @@ import Core
 
 public final class ReviewDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: ReviewDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: ReviewDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(container: Container, reviewId: String) {
         self.container = container
+        self.rootViewController = container.resolve(ReviewDetailViewController.self, argument: reviewId)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? ReviewDetailStep else { return .none }
 
         switch step {
-        case let .reviewDetailIsRequired(reviewId):
-            return navigateToReviewDetail(reviewId: reviewId)
+        case .reviewDetailIsRequired:
+            return navigateToReviewDetail()
         }
     }
 }
 
 private extension ReviewDetailFlow {
-    func navigateToReviewDetail(reviewId: String) -> FlowContributors {
-        rootViewController = container.resolve(ReviewDetailViewController.self, argument: reviewId)!
+    func navigateToReviewDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Review/ReviewFilterFlow.swift
+++ b/Projects/Flow/Sources/Review/ReviewFilterFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class ReviewFilterFlow: Flow {
     public let container: Container
-    private var rootViewController: ReviewFilterViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: ReviewFilterViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(ReviewFilterViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -28,7 +31,6 @@ public final class ReviewFilterFlow: Flow {
 
 private extension ReviewFilterFlow {
     func navigateToReviewFilter() -> FlowContributors {
-        rootViewController = container.resolve(ReviewFilterViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Review/ReviewFlow.swift
+++ b/Projects/Flow/Sources/Review/ReviewFlow.swift
@@ -52,7 +52,7 @@ private extension ReviewFlow {
     }
 
     func navigateToReviewDetail(_ reviewID: String) -> FlowContributors {
-        let reviewDetailFlow = ReviewDetailFlow(container: container)
+        let reviewDetailFlow = ReviewDetailFlow(container: container, reviewId: reviewID)
 
         Flows.use(reviewDetailFlow, when: .created) { [weak self] (view: ReviewDetailViewController) in
             view.isPopViewController = { [weak nav = self?.rootViewController] _ in
@@ -64,7 +64,7 @@ private extension ReviewFlow {
 
         return .one(flowContributor: .contribute(
             withNextPresentable: reviewDetailFlow,
-            withNextStepper: OneStepper(withSingleStep: ReviewDetailStep.reviewDetailIsRequired(reviewId: reviewID))
+            withNextStepper: OneStepper(withSingleStep: ReviewDetailStep.reviewDetailIsRequired)
         ))
     }
 

--- a/Projects/Flow/Sources/Review/SearchReviewFlow.swift
+++ b/Projects/Flow/Sources/Review/SearchReviewFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class SearchReviewFlow: Flow {
     public let container: Container
-    private var rootViewController: SearchReviewViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: SearchReviewViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(SearchReviewViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -25,7 +28,6 @@ public final class SearchReviewFlow: Flow {
 
 private extension SearchReviewFlow {
     func navigateToSearchReview() -> FlowContributors {
-        rootViewController = container.resolve(SearchReviewViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Signin/SigninFlow.swift
+++ b/Projects/Flow/Sources/Signin/SigninFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class SigninFlow: Flow {
     public let container: Container
-    private var rootViewController: SigninViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: SigninViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = SigninViewController(container.resolve(SigninReactor.self)!)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -31,7 +34,6 @@ public final class SigninFlow: Flow {
 
 private extension SigninFlow {
     func navigateToSignin() -> FlowContributors {
-        rootViewController = container.resolve(SigninViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Signup/GenderSettingFlow.swift
+++ b/Projects/Flow/Sources/Signup/GenderSettingFlow.swift
@@ -6,13 +6,15 @@ import Core
 
 public final class GenderSettingFlow: Flow {
     public let container: Container
-    private var rootViewController: GenderSettingViewController!
+    private let rootViewController: GenderSettingViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, name: String, gcn: Int, email: String, password: String) {
         self.container = container
+        let reactor = container.resolve(GenderSettingReactor.self, arguments: name, gcn, email, password)!
+        self.rootViewController = GenderSettingViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -49,8 +51,6 @@ private extension GenderSettingFlow {
         email: String,
         password: String
     ) -> FlowContributors {
-        let reactor = container.resolve(GenderSettingReactor.self, arguments: name, gcn, email, password)!
-        rootViewController = GenderSettingViewController(reactor)
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -64,7 +64,7 @@ private extension GenderSettingFlow {
         password: String,
         isMan: Bool
     ) -> FlowContributors {
-        let profileSettingFlow = ProfileSettingFlow(container: container)
+        let profileSettingFlow = ProfileSettingFlow(container: container, name: name, gcn: gcn, email: email, password: password, isMan: isMan)
 
         Flows.use(profileSettingFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/Signup/InfoSettingFlow.swift
+++ b/Projects/Flow/Sources/Signup/InfoSettingFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class InfoSettingFlow: Flow {
     public let container: Container
-    private var rootViewController: InfoSettingViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: InfoSettingViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(InfoSettingViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -31,7 +34,6 @@ public final class InfoSettingFlow: Flow {
 
 private extension InfoSettingFlow {
     func navigateToInfoSetting() -> FlowContributors {
-        rootViewController = container.resolve(InfoSettingViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -39,7 +41,7 @@ private extension InfoSettingFlow {
     }
 
     func navigateToVerifyEmail(name: String, gcn: Int) -> FlowContributors {
-        let verifyEmailFlow = VerifyEmailFlow(container: container)
+        let verifyEmailFlow = VerifyEmailFlow(container: container, name: name, gcn: gcn)
 
         Flows.use(verifyEmailFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/Signup/PasswordSettingFlow.swift
+++ b/Projects/Flow/Sources/Signup/PasswordSettingFlow.swift
@@ -6,13 +6,15 @@ import Core
 
 public final class PasswordSettingFlow: Flow {
     public let container: Container
-    private var rootViewController: PasswordSettingViewController!
+    private let rootViewController: PasswordSettingViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, name: String, gcn: Int, email: String) {
         self.container = container
+        let reactor = container.resolve(PasswordSettingReactor.self, arguments: name, gcn, email)!
+        self.rootViewController = PasswordSettingViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -33,8 +35,6 @@ public final class PasswordSettingFlow: Flow {
 
 private extension PasswordSettingFlow {
     func navigateToPasswordSetting(name: String, gcn: Int, email: String) -> FlowContributors {
-        let reactor = container.resolve(PasswordSettingReactor.self, arguments: name, gcn, email)!
-        rootViewController = PasswordSettingViewController(reactor)
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -47,7 +47,7 @@ private extension PasswordSettingFlow {
         email: String,
         password: String
     ) -> FlowContributors {
-        let genderFlow = GenderSettingFlow(container: container)
+        let genderFlow = GenderSettingFlow(container: container, name: name, gcn: gcn, email: email, password: password)
 
         Flows.use(genderFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/Signup/PrivacyFlow.swift
+++ b/Projects/Flow/Sources/Signup/PrivacyFlow.swift
@@ -6,13 +6,15 @@ import Core
 
 public final class PrivacyFlow: Flow {
     public let container: Container
-    private var rootViewController: PrivacyViewController!
+    private let rootViewController: PrivacyViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, name: String, gcn: Int, email: String, password: String, isMan: Bool, profileImageURL: String?) {
         self.container = container
+        let reactor = container.resolve(PrivacyReactor.self, arguments: name, gcn, email, password, isMan, profileImageURL)!
+        self.rootViewController = PrivacyViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -44,8 +46,6 @@ private extension PrivacyFlow {
         isMan: Bool,
         profileImageURL: String?
     ) -> FlowContributors {
-        let reactor = container.resolve(PrivacyReactor.self, arguments: name, gcn, email, password, isMan, profileImageURL)!
-        rootViewController = PrivacyViewController(reactor)
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor

--- a/Projects/Flow/Sources/Signup/ProfileSettingFlow.swift
+++ b/Projects/Flow/Sources/Signup/ProfileSettingFlow.swift
@@ -6,13 +6,15 @@ import Core
 
 public final class ProfileSettingFlow: Flow {
     public let container: Container
-    private var rootViewController: ProfileSettingViewController!
+    private let rootViewController: ProfileSettingViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, name: String, gcn: Int, email: String, password: String, isMan: Bool) {
         self.container = container
+        let reactor = container.resolve(ProfileSettingReactor.self, arguments: name, gcn, email, password, isMan)!
+        self.rootViewController = ProfileSettingViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -52,8 +54,6 @@ private extension ProfileSettingFlow {
         password: String,
         isMan: Bool
     ) -> FlowContributors {
-        let reactor = container.resolve(ProfileSettingReactor.self, arguments: name, gcn, email, password, isMan)!
-        rootViewController = ProfileSettingViewController(reactor)
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -68,7 +68,7 @@ private extension ProfileSettingFlow {
         isMan: Bool,
         profileImageURL: String?
     ) -> FlowContributors {
-        let privacyFlow = PrivacyFlow(container: container)
+        let privacyFlow = PrivacyFlow(container: container, name: name, gcn: gcn, email: email, password: password, isMan: isMan, profileImageURL: profileImageURL)
 
         Flows.use(privacyFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/Signup/VerifyEmailFlow.swift
+++ b/Projects/Flow/Sources/Signup/VerifyEmailFlow.swift
@@ -6,13 +6,15 @@ import Core
 
 public final class VerifyEmailFlow: Flow {
     public let container: Container
-    private var rootViewController: VerifyEmailViewController!
+    private let rootViewController: VerifyEmailViewController
     public var root: Presentable {
         return rootViewController
     }
 
-    public init(container: Container) {
+    public init(container: Container, name: String, gcn: Int) {
         self.container = container
+        let reactor = container.resolve(VerifyEmailReactor.self, arguments: name, gcn)!
+        self.rootViewController = VerifyEmailViewController(reactor)
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -33,8 +35,6 @@ public final class VerifyEmailFlow: Flow {
 
 private extension VerifyEmailFlow {
     func navigateToVerifyEmail(name: String, gcn: Int) -> FlowContributors {
-        let reactor = container.resolve(VerifyEmailReactor.self, arguments: name, gcn)!
-        rootViewController = VerifyEmailViewController(reactor)
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -42,7 +42,7 @@ private extension VerifyEmailFlow {
     }
 
     func navigateToPasswordSetting(name: String, gcn: Int, email: String) -> FlowContributors {
-        let passwordSettingFlow = PasswordSettingFlow(container: container)
+        let passwordSettingFlow = PasswordSettingFlow(container: container, name: name, gcn: gcn, email: email)
 
         Flows.use(passwordSettingFlow, when: .created) { root in
             self.rootViewController.navigationController?.pushViewController(

--- a/Projects/Flow/Sources/WinterIntern/WinterInternDetailFlow.swift
+++ b/Projects/Flow/Sources/WinterIntern/WinterInternDetailFlow.swift
@@ -6,19 +6,25 @@ import Core
 
 public final class WinterInternDetailFlow: Flow {
     public let container: Container
-    private var rootViewController: WinterInternDetailViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: WinterInternDetailViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
-    public init(container: Container) {
+    public init(container: Container, recruitmentID: Int? = nil, companyId: Int? = nil, type: RecruitmentDetailPreviousViewType = .recruitmentList) {
         self.container = container
+        self.rootViewController = container.resolve(
+            WinterInternDetailViewController.self,
+            arguments: recruitmentID, companyId, type
+        )!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
         guard let step = step as? RecruitmentDetailStep else { return .none }
 
         switch step {
-        case let .recruitmentDetailIsRequired(id, companyId, type):
-            return navigateToRecruitmentDetail(id: id, companyId: companyId, type: type)
+        case .recruitmentDetailIsRequired:
+            return navigateToRecruitmentDetail()
 
         case let .companyDetailIsRequired(id):
             return navigateToCompanyDetail(id)
@@ -30,15 +36,7 @@ public final class WinterInternDetailFlow: Flow {
 }
 
 private extension WinterInternDetailFlow {
-    func navigateToRecruitmentDetail(
-        id: Int?,
-        companyId: Int?,
-        type: RecruitmentDetailPreviousViewType
-    ) -> FlowContributors {
-        rootViewController = container.resolve(
-            WinterInternDetailViewController.self,
-            arguments: id, companyId, type
-        )!
+    func navigateToRecruitmentDetail() -> FlowContributors {
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -46,7 +44,11 @@ private extension WinterInternDetailFlow {
     }
 
     func navigateToCompanyDetail(_ companyDetailId: Int) -> FlowContributors {
-        let companyDetailFlow = CompanyDetailFlow(container: container)
+        let companyDetailFlow = CompanyDetailFlow(
+            container: container,
+            companyId: companyDetailId,
+            type: .recruitmentDetail
+        )
 
         Flows.use(companyDetailFlow, when: .created) { (root) in
             self.rootViewController.navigationController?.pushViewController(
@@ -57,16 +59,20 @@ private extension WinterInternDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: companyDetailFlow,
             withNextStepper: OneStepper(
-                withSingleStep: CompanyDetailStep.companyDetailIsRequired(
-                    companyId: companyDetailId,
-                    type: .recruitmentDetail
-                )
+                withSingleStep: CompanyDetailStep.companyDetailIsRequired
             )
         ))
     }
 
     func navigateToApply(id: Int, name: String, imageURL: String) -> FlowContributors {
-        let applyFlow = ApplyFlow(container: container)
+        let applyFlow = ApplyFlow(
+            container: container,
+            recruitmentId: id,
+            applicationId: nil,
+            companyName: name,
+            companyImageURL: imageURL,
+            applyType: .apply
+        )
 
         Flows.use(applyFlow, when: .created) { (root) in
             self.rootViewController.navigationController?.pushViewController(
@@ -78,11 +84,7 @@ private extension WinterInternDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: applyFlow,
             withNextStepper: OneStepper(
-                withSingleStep: ApplyStep.applyIsRequired(
-                    recruitmentId: id,
-                    name: name,
-                    imageURL: imageURL
-                )
+                withSingleStep: ApplyStep.applyIsRequired(recruitmentId: id, name: name, imageURL: imageURL)
             )
         ))
     }

--- a/Projects/Flow/Sources/WinterIntern/WinterInternDetailFlow.swift
+++ b/Projects/Flow/Sources/WinterIntern/WinterInternDetailFlow.swift
@@ -84,7 +84,7 @@ private extension WinterInternDetailFlow {
         return .one(flowContributor: .contribute(
             withNextPresentable: applyFlow,
             withNextStepper: OneStepper(
-                withSingleStep: ApplyStep.applyIsRequired(recruitmentId: id, name: name, imageURL: imageURL)
+                withSingleStep: ApplyStep.applyIsRequired
             )
         ))
     }

--- a/Projects/Flow/Sources/WinterIntern/WinterInternFlow.swift
+++ b/Projects/Flow/Sources/WinterIntern/WinterInternFlow.swift
@@ -6,11 +6,14 @@ import Core
 
 public final class WinterInternFlow: Flow {
     public let container: Container
-    private var rootViewController: WinterInternViewController!
-    public var root: Presentable { rootViewController! }
+    private let rootViewController: WinterInternViewController
+    public var root: Presentable {
+        return rootViewController
+    }
 
     public init(container: Container) {
         self.container = container
+        self.rootViewController = container.resolve(WinterInternViewController.self)!
     }
 
     public func navigate(to step: Step) -> FlowContributors {
@@ -34,7 +37,6 @@ public final class WinterInternFlow: Flow {
 
 private extension WinterInternFlow {
     func navigateToRecruitment() -> FlowContributors {
-        rootViewController = container.resolve(WinterInternViewController.self)!
         return .one(flowContributor: .contribute(
             withNextPresentable: rootViewController,
             withNextStepper: rootViewController.reactor
@@ -42,12 +44,16 @@ private extension WinterInternFlow {
     }
 
     func navigateToRecruitmentDetail(recruitmentID: Int) -> FlowContributors {
-        let winterInternDetailFlow = WinterInternDetailFlow(container: container)
+        let recruitmentDetailFlow = WinterInternDetailFlow(
+            container: container,
+            recruitmentID: recruitmentID
+        )
 
-        Flows.use(winterInternDetailFlow, when: .created) { (root) in
+        Flows.use(recruitmentDetailFlow, when: .created) { (root) in
             let view = root as? WinterInternDetailViewController
-            view?.isPopViewController = { _, _ in
-                self.rootViewController.isTabNavigation = false
+            view?.isPopViewController = { id, bookmark in
+                let popView = self.rootViewController
+                popView.isTabNavigation = false
             }
             self.rootViewController.navigationController?.pushViewController(
                 view!, animated: true
@@ -55,14 +61,8 @@ private extension WinterInternFlow {
         }
 
         return .one(flowContributor: .contribute(
-            withNextPresentable: winterInternDetailFlow,
-            withNextStepper: OneStepper(
-                withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired(
-                    id: recruitmentID,
-                    companyId: nil,
-                    type: .recruitmentList
-                )
-            )
+            withNextPresentable: recruitmentDetailFlow,
+            withNextStepper: OneStepper(withSingleStep: RecruitmentDetailStep.recruitmentDetailIsRequired)
         ))
     }
 

--- a/Projects/Presentation/Sources/Notice/NoticeDetailViewController.swift
+++ b/Projects/Presentation/Sources/Notice/NoticeDetailViewController.swift
@@ -23,6 +23,20 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
         $0.numberOfLines = 0
         $0.lineBreakMode = .byWordWrapping
     }
+    private let attachmentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 8
+        $0.isHidden = true
+    }
+    private let attachmentTitleLabel = UILabel().then {
+        $0.setJobisText("첨부파일", font: .headLine, color: .GrayScale.gray80)
+    }
+
+    private var s3BaseURL: URL {
+        URL(
+            string: Bundle.main.object(forInfoDictionaryKey: "S3_BASE_URL") as? String ?? ""
+        ) ?? URL(string: "https://www.google.com")!
+    }
 
     public override func addView() {
         view.addSubview(scrollView)
@@ -30,7 +44,9 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
         [
             noticeTitleLabel,
             noticeDateLabel,
-            noticeContentLabel
+            noticeContentLabel,
+            attachmentTitleLabel,
+            attachmentStackView
         ].forEach(contentView.addSubview(_:))
     }
 
@@ -42,7 +58,7 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
         contentView.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalToSuperview()
-            $0.bottom.equalTo(noticeContentLabel.snp.bottom).offset(20)
+            $0.bottom.equalTo(attachmentStackView.snp.bottom).offset(20)
         }
 
         noticeTitleLabel.snp.makeConstraints {
@@ -59,6 +75,16 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
             $0.top.equalTo(noticeDateLabel.snp.bottom).offset(16)
             $0.left.right.equalToSuperview().inset(24)
         }
+
+        attachmentTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(noticeContentLabel.snp.bottom).offset(24)
+            $0.left.right.equalToSuperview().inset(24)
+        }
+
+        attachmentStackView.snp.makeConstraints {
+            $0.top.equalTo(attachmentTitleLabel.snp.bottom).offset(8)
+            $0.left.right.equalToSuperview().inset(24)
+        }
     }
 
     public override func bindAction() {
@@ -71,13 +97,15 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
     public override func bindState() {
         reactor.state.compactMap { $0.noticeDetail }
             .subscribe(onNext: { [weak self] detail in
-                self?.noticeTitleLabel.text = detail.title
-                self?.noticeDateLabel.setJobisText(
+                guard let self else { return }
+                self.noticeTitleLabel.text = detail.title
+                self.noticeDateLabel.setJobisText(
                     detail.createdAt,
                     font: .description,
                     color: .GrayScale.gray60
                 )
-                self?.noticeContentLabel.text = detail.content
+                self.noticeContentLabel.text = detail.content
+                self.configureAttachments(detail.attachments)
             })
             .disposed(by: disposeBag)
     }
@@ -87,5 +115,48 @@ public final class NoticeDetailViewController: BaseReactorViewController<NoticeD
     public override func configureNavigation() {
         setSmallTitle(title: "공지사항")
         navigationItem.largeTitleDisplayMode = .never
+    }
+
+    private func configureAttachments(_ attachments: [AttachmentsEntity]) {
+        attachmentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        guard !attachments.isEmpty else {
+            attachmentTitleLabel.isHidden = true
+            attachmentStackView.isHidden = true
+            return
+        }
+
+        attachmentTitleLabel.isHidden = false
+        attachmentStackView.isHidden = false
+
+        for attachment in attachments {
+            let fileName = attachment.url.components(separatedBy: "/").last?
+                .components(separatedBy: "-").dropFirst().joined(separator: "-")
+                ?? attachment.url
+
+            let button = UIButton(type: .system).then {
+                $0.setTitle("📎 \(fileName)", for: .normal)
+                $0.titleLabel?.font = .systemFont(ofSize: 14)
+                $0.contentHorizontalAlignment = .left
+                $0.backgroundColor = .GrayScale.gray20
+                $0.layer.cornerRadius = 8
+                $0.contentEdgeInsets = UIEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+            }
+
+            let fileURL: URL
+            if attachment.url.hasPrefix("http") {
+                fileURL = URL(string: attachment.url) ?? s3BaseURL
+            } else {
+                fileURL = s3BaseURL.appendingPathComponent(attachment.url)
+            }
+
+            button.rx.tap
+                .subscribe(onNext: { _ in
+                    UIApplication.shared.open(fileURL)
+                })
+                .disposed(by: disposeBag)
+
+            attachmentStackView.addArrangedSubview(button)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- 전체 Flow 파일(50개)의 lazy 패턴 제거: `rootViewController`를 `init`에서 resolve하도록 원복 → RxFlow Coordinator가 `navigate(to:)` 전에 `flow.root` 접근 시 발생하던 IUO 크래시 해결
- `RejectReasonFlow`: 4개 인자를 `init`으로 이동하여 동일 크래시 수정
- 관련 Step enum 연관값 정리
- `NoticeDetailViewController`에 첨부파일 다운로드 버튼 추가 (S3_BASE_URL + attachment URL → Safari)

## Test plan

- [ ] 마이페이지 → 공지사항 진입 크래시 없는지 확인
- [ ] 공지사항 상세 진입 크래시 없는지 확인
- [ ] 공지사항 상세에서 첨부파일 버튼 노출 및 탭 시 Safari 열기 확인
- [ ] 다른 Flow 진입 (북마크, 알림, 관심분야 등) 크래시 없는지 확인

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공고 상세 페이지에 첨부파일 표시 기능 추가

* **개선**
  * 앱의 내부 아키텍처 안정성 및 성능 개선
  * 네비게이션 흐름 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->