### PR TITLE
🔗 :: (#427) Swift DocC Tutorial 추가 — 새 화면 추가 개발 가이드

### DIFF
--- a/Projects/Domain/Documentation/Domain.docc/Domain.md
+++ b/Projects/Domain/Documentation/Domain.docc/Domain.md
@@ -1,0 +1,16 @@
+# ``Domain``
+
+JOBIS iOS 앱의 비즈니스 로직 레이어입니다.
+
+## 개요
+
+`Domain` 모듈은 UseCase, Repository 프로토콜, Entity 등 핵심 비즈니스 로직을 포함합니다.
+외부 레이어(Data, Presentation)에 의존하지 않습니다.
+
+## 개발 가이드
+
+새로운 기능을 추가할 때는 아래 튜토리얼을 참고하세요.
+
+@Links(visualStyle: list) {
+    - <doc:JOBIS>
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/AddNewFeature.tutorial
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/AddNewFeature.tutorial
@@ -1,0 +1,191 @@
+@Tutorial(time: 40) {
+    @Intro(title: "공지사항 기능으로 알아보는 튜토리얼") {
+        JOBIS 아키텍처에서 새 기능을 추가할 때 거쳐야 하는 8단계를 공지사항(Notice) 기능을 예시로 설명합니다.
+
+        전체 흐름: **Core → Domain → Data → Presentation → Flow**
+    }
+
+    @Section(title: "1단계: Step 정의 (Core)") {
+        @ContentAndMedia {
+            `Core` 모듈의 `Steps/` 폴더에 화면 전환용 Step enum을 추가합니다.
+
+            Step은 RxFlow에서 화면 전환 의도를 표현하는 타입입니다.
+            각 화면마다 별도 파일로 분리합니다.
+
+            > Important: 데이터가 필요한 경우 연관값으로 전달합니다.
+            > `rootViewController`를 `init`에서 resolve해야 하므로
+            > Flow 생성 시점에 필요한 데이터는 Step 연관값이 아닌
+            > **Flow의 `init`에 직접 전달**해야 합니다.
+        }
+
+        @Steps {
+            @Step {
+                `Core/Sources/Steps/` 폴더에 `NoticeStep.swift`를 생성합니다.
+                목록 화면과 상세 화면 두 개의 케이스를 정의합니다.
+
+                @Code(name: "NoticeStep.swift", file: "01-notice-step.swift")
+            }
+
+            @Step {
+                상세 화면처럼 ID가 필요한 경우, 해당 ID를 **Flow의 `init`에 전달**하기 위해
+                별도 Step 파일에 연관값 없이 정의합니다.
+
+                @Code(name: "NoticeDetailStep.swift", file: "02-notice-detail-step.swift")
+            }
+        }
+    }
+
+    @Section(title: "2단계: Entity 및 Repository 프로토콜 정의 (Domain)") {
+        @ContentAndMedia {
+            `Domain` 모듈에 비즈니스 데이터 모델(Entity)과 Repository 프로토콜을 추가합니다.
+
+            Domain은 외부 레이어(Data, Presentation)에 의존하지 않으며,
+            순수한 비즈니스 로직만 포함합니다.
+        }
+
+        @Steps {
+            @Step {
+                `Domain/Sources/Entities/Notice/` 폴더에 Entity를 정의합니다.
+
+                @Code(name: "NoticeDetailEntity.swift", file: "03-notice-detail-entity.swift")
+            }
+
+            @Step {
+                `Domain/Sources/Repositories/` 폴더에 Repository 프로토콜을 정의합니다.
+                구현체는 Data 레이어에 있습니다.
+
+                @Code(name: "NoticesRepository.swift", file: "04-notices-repository.swift")
+            }
+        }
+    }
+
+    @Section(title: "3단계: UseCase 추가 (Domain)") {
+        @ContentAndMedia {
+            `Domain/Sources/UseCases/` 폴더에 UseCase를 추가합니다.
+
+            UseCase는 Repository 프로토콜을 주입받아 단일 비즈니스 동작을 `execute()`로 노출합니다.
+            Reactor에서 직접 이 UseCase를 호출합니다.
+        }
+
+        @Steps {
+            @Step {
+                `Domain/Sources/UseCases/Notice/` 폴더에 UseCase 파일을 만듭니다.
+
+                @Code(name: "FetchNoticeDetailUseCase.swift", file: "05-fetch-notice-detail-usecase.swift")
+            }
+        }
+    }
+
+    @Section(title: "4단계: API, DTO, DataSource, Repository 구현 (Data)") {
+        @ContentAndMedia {
+            `Data` 모듈에서 실제 네트워크 통신을 구현합니다.
+
+            - **API**: Moya `TargetType` 기반 엔드포인트 정의
+            - **DTO**: 서버 응답 JSON → Swift 구조체 디코딩
+            - **DataSource**: API 호출 및 DTO → Entity 변환
+            - **Repository**: DataSource를 감싸는 구현체
+        }
+
+        @Steps {
+            @Step {
+                `Data/Sources/DataSource/API/` 폴더에 API enum을 만듭니다.
+                `JobisAPI` 프로토콜을 채택하면 `baseURL`이 자동으로 `Info.plist`의 `API_BASE_URL`을 사용합니다.
+
+                @Code(name: "NoticeAPI.swift", file: "06-notice-api.swift")
+            }
+
+            @Step {
+                `Data/Sources/DTO/Notice/` 폴더에 응답 DTO를 만듭니다.
+                `toDomain()` 메서드로 Entity로 변환합니다.
+
+                @Code(name: "NoticeDetailResponseDTO.swift", file: "07-notice-detail-dto.swift")
+            }
+
+            @Step {
+                `Data/Sources/DataSource/Remote/` 폴더에 DataSource 프로토콜과 구현체를 만듭니다.
+
+                @Code(name: "RemoteNoticesDataSource.swift", file: "08-remote-notices-datasource.swift")
+            }
+        }
+    }
+
+    @Section(title: "5단계: Reactor + ViewController 추가 (Presentation)") {
+        @ContentAndMedia {
+            `Presentation` 모듈에 화면 로직(Reactor)과 UI(ViewController)를 추가합니다.
+
+            - **Reactor**: Action → Mutation → State 단방향 데이터 흐름
+            - **ViewController**: State를 구독해 UI 업데이트, Action을 Reactor로 전달
+        }
+
+        @Steps {
+            @Step {
+                `Presentation/Sources/Notice/` 폴더에 `NoticeDetailReactor.swift`를 만듭니다.
+                `Stepper`를 채택해 화면 전환 이벤트를 방출합니다.
+
+                @Code(name: "NoticeDetailReactor.swift", file: "09-notice-detail-reactor.swift")
+            }
+
+            @Step {
+                같은 폴더에 `NoticeDetailViewController.swift`를 만듭니다.
+                `BaseReactorViewController<NoticeDetailReactor>`를 상속합니다.
+
+                @Code(name: "NoticeDetailViewController.swift", file: "10-notice-detail-viewcontroller.swift")
+            }
+        }
+    }
+
+    @Section(title: "6단계: DI Assembly 등록 (Presentation)") {
+        @ContentAndMedia {
+            `Presentation/Sources/DI/Assembly/` 폴더에 있는 Assembly에
+            Reactor와 ViewController를 등록합니다.
+
+            > Important: Reactor와 ViewController 모두 등록해야 합니다.
+            > ViewController에 주입되는 Reactor도 반드시 같은 Assembly 내에 등록되어 있어야 합니다.
+        }
+
+        @Steps {
+            @Step {
+                기능과 관련된 Assembly 파일(예: `SettingPresentationAssembly.swift`)을 찾아
+                Reactor와 ViewController를 `container.register`로 추가합니다.
+
+                @Code(name: "SettingPresentationAssembly.swift", file: "11-assembly-registration.swift")
+            }
+        }
+    }
+
+    @Section(title: "7단계: Flow 추가 (Flow)") {
+        @ContentAndMedia {
+            `Flow` 모듈에 화면의 네비게이션을 담당하는 Flow를 추가합니다.
+
+            > Important: `rootViewController`는 반드시 **`init`에서** `container.resolve()`로 초기화해야 합니다.
+            > `navigate(to:)` 안에서 초기화하면 RxFlow Coordinator가 `flow.root`에 먼저 접근할 때 nil 크래시가 발생합니다.
+            >
+            > ID 등 데이터가 필요한 경우에도 Flow의 `init(container:data:)` 파라미터로 받아 즉시 resolve하세요.
+        }
+
+        @Steps {
+            @Step {
+                `Flow/Sources/MyPage/Notice/` 폴더에 `NoticeDetailFlow.swift`를 만듭니다.
+                `rootViewController`를 `init`에서 resolve합니다.
+
+                @Code(name: "NoticeDetailFlow.swift", file: "12-notice-detail-flow.swift")
+            }
+        }
+    }
+
+    @Section(title: "8단계: 부모 Flow에서 연결") {
+        @ContentAndMedia {
+            자식 Flow를 부모 Flow의 `navigate(to:)` 안에서 생성하고,
+            `Flows.use`로 실제 화면 전환을 처리합니다.
+        }
+
+        @Steps {
+            @Step {
+                부모 Flow(`NoticeFlow.swift`)에서 Step을 받아 `NoticeDetailFlow`를 생성합니다.
+                데이터(`id`)는 Flow `init`에 직접 전달합니다.
+
+                @Code(name: "NoticeFlow.swift", file: "13-notice-flow-parent.swift")
+            }
+        }
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/01-notice-step.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/01-notice-step.swift
@@ -1,0 +1,6 @@
+import RxFlow
+
+public enum NoticeStep: Step {
+    case noticeIsRequired
+    case noticeDetailIsRequired(id: Int)
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/02-notice-detail-step.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/02-notice-detail-step.swift
@@ -1,0 +1,8 @@
+import RxFlow
+
+// NoticeDetailFlow의 init에 noticeID를 전달하므로
+// Step에는 연관값이 필요 없습니다.
+public enum NoticeDetailStep: Step {
+    case noticeDetailIsRequired
+    case noticeListIsRequired
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/03-notice-detail-entity.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/03-notice-detail-entity.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct NoticeDetailEntity: Equatable, Hashable {
+    public let title: String
+    public let content: String
+    public let createdAt: String
+    public let attachments: [AttachmentsEntity]
+
+    public init(title: String, content: String, createdAt: String, attachments: [AttachmentsEntity]) {
+        self.title = title
+        self.content = content
+        self.createdAt = createdAt
+        self.attachments = attachments
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/04-notices-repository.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/04-notices-repository.swift
@@ -1,0 +1,8 @@
+import RxSwift
+
+// Domain 레이어에 프로토콜만 정의합니다.
+// 실제 구현체는 Data 레이어에 있습니다.
+public protocol NoticesRepository {
+    func fetchNoticeList() -> Single<[NoticeEntity]>
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity>
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/05-fetch-notice-detail-usecase.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/05-fetch-notice-detail-usecase.swift
@@ -1,0 +1,15 @@
+import RxSwift
+
+// UseCase는 단일 책임: execute() 하나만 노출합니다.
+// Repository는 생성자 주입(Swinject)으로 받습니다.
+public struct FetchNoticeDetailUseCase {
+    private let noticesRepository: any NoticesRepository
+
+    public init(noticesRepository: any NoticesRepository) {
+        self.noticesRepository = noticesRepository
+    }
+
+    public func execute(id: Int) -> Single<NoticeDetailEntity> {
+        return noticesRepository.fetchNoticeDetail(id: id)
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/06-notice-api.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/06-notice-api.swift
@@ -1,0 +1,44 @@
+import Moya
+import Domain
+import AppNetwork
+
+enum NoticeAPI {
+    case fetchNoticeList
+    case fetchNoticeDetail(id: Int)
+}
+
+extension NoticeAPI: JobisAPI {
+    typealias ErrorType = JobisError
+
+    var domain: JobisDomain {
+        return .notices  // /notices 경로
+    }
+
+    var urlPath: String {
+        switch self {
+        case .fetchNoticeList:
+            return ""           // GET /notices
+        case let .fetchNoticeDetail(id):
+            return "/\(id)"     // GET /notices/{id}
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .fetchNoticeList, .fetchNoticeDetail:
+            return .get
+        }
+    }
+
+    var task: Task {
+        return .requestPlain
+    }
+
+    var jwtTokenType: JwtTokenType {
+        return .accessToken
+    }
+
+    var errorMap: [Int: ErrorType]? {
+        return nil
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/07-notice-detail-dto.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/07-notice-detail-dto.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Domain
+import Utility
+
+// 서버 응답 JSON을 디코딩하는 구조체
+struct NoticeDetailResponseDTO: Decodable {
+    let title: String
+    let content: String
+    let createdAt: String           // snake_case → camelCase 변환
+    let attachments: [AttachmentsResponseDTO]?
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case content
+        case createdAt = "created_at"
+        case attachments
+    }
+}
+
+extension NoticeDetailResponseDTO {
+    // DTO → Domain Entity 변환
+    func toDomain() -> NoticeDetailEntity {
+        return NoticeDetailEntity(
+            title: title,
+            content: content,
+            createdAt: createdAt.toJobisDate().toStringFormat("yyyy-MM-dd"),
+            attachments: attachments?.compactMap { $0.toDomain() } ?? []
+        )
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/08-remote-notices-datasource.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/08-remote-notices-datasource.swift
@@ -1,0 +1,24 @@
+import RxSwift
+import Domain
+
+// 프로토콜: Domain에서 사용하는 인터페이스
+public protocol RemoteNoticesDataSource {
+    func fetchNoticeList() -> Single<[NoticeEntity]>
+    func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity>
+}
+
+// 구현체: RemoteBaseDataSource<API>를 상속해 request()를 사용
+final class RemoteNoticesDataSourceImpl: RemoteBaseDataSource<NoticeAPI>, RemoteNoticesDataSource {
+
+    public func fetchNoticeList() -> Single<[NoticeEntity]> {
+        request(.fetchNoticeList)
+            .map(NoticeListResponseDTO.self)
+            .map { $0.toDomain() }
+    }
+
+    public func fetchNoticeDetail(id: Int) -> Single<NoticeDetailEntity> {
+        request(.fetchNoticeDetail(id: id))
+            .map(NoticeDetailResponseDTO.self)
+            .map { $0.toDomain() }
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/09-notice-detail-reactor.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/09-notice-detail-reactor.swift
@@ -1,0 +1,56 @@
+import ReactorKit
+import RxSwift
+import RxFlow
+import Core
+import Domain
+
+public final class NoticeDetailReactor: BaseReactor, Stepper {
+    public let steps = PublishRelay<Step>()
+    public let initialState: State
+    private let fetchNoticeDetailUseCase: FetchNoticeDetailUseCase
+    public let noticeID: Int
+
+    public init(
+        noticeID: Int,
+        fetchNoticeDetailUseCase: FetchNoticeDetailUseCase
+    ) {
+        self.noticeID = noticeID
+        self.initialState = .init()
+        self.fetchNoticeDetailUseCase = fetchNoticeDetailUseCase
+    }
+
+    // MARK: - Action: ViewController → Reactor
+    public enum Action {
+        case fetchNoticeDetail
+    }
+
+    // MARK: - Mutation: 상태 변경 단위
+    public enum Mutation {
+        case setNoticeDetail(NoticeDetailEntity)
+    }
+
+    // MARK: - State: UI에 바인딩되는 상태
+    public struct State {
+        var noticeDetail: NoticeDetailEntity?
+    }
+}
+
+extension NoticeDetailReactor {
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .fetchNoticeDetail:
+            return fetchNoticeDetailUseCase.execute(id: noticeID)
+                .asObservable()
+                .map { Mutation.setNoticeDetail($0) }
+        }
+    }
+
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .setNoticeDetail(detail):
+            newState.noticeDetail = detail
+        }
+        return newState
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/10-notice-detail-viewcontroller.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/10-notice-detail-viewcontroller.swift
@@ -1,0 +1,50 @@
+import UIKit
+import RxSwift
+import SnapKit
+import Then
+import Core
+
+// BaseReactorViewController를 상속하면 reactor, disposeBag, viewDidLoadPublisher가 자동 제공됩니다.
+public final class NoticeDetailViewController: BaseReactorViewController<NoticeDetailReactor> {
+    private let titleLabel = UILabel()
+    private let contentLabel = UILabel().then {
+        $0.numberOfLines = 0
+    }
+
+    // MARK: - Layout
+    public override func addView() {
+        [titleLabel, contentLabel].forEach(view.addSubview(_:))
+    }
+
+    public override func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+        contentLabel.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(24)
+        }
+    }
+
+    // MARK: - Bind Action: ViewController → Reactor
+    public override func bindAction() {
+        viewDidLoadPublisher
+            .map { NoticeDetailReactor.Action.fetchNoticeDetail }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Bind State: Reactor → ViewController
+    public override func bindState() {
+        reactor.state.compactMap { $0.noticeDetail }
+            .subscribe(onNext: { [weak self] detail in
+                self?.titleLabel.text = detail.title
+                self?.contentLabel.text = detail.content
+            })
+            .disposed(by: disposeBag)
+    }
+
+    public override func configureNavigation() {
+        setSmallTitle(title: "공지사항")
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/11-assembly-registration.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/11-assembly-registration.swift
@@ -1,0 +1,26 @@
+import Swinject
+import Domain
+
+public struct SettingPresentationAssembly: Assembly {
+    public func assemble(container: Container) {
+
+        // ... 기존 등록 코드 ...
+
+        // MARK: - Notice Detail 등록
+
+        // 1. Reactor 등록: argument로 noticeID를 받습니다.
+        container.register(NoticeDetailReactor.self) { (resolver: Resolver, noticeID: Int) in
+            NoticeDetailReactor(
+                noticeID: noticeID,
+                fetchNoticeDetailUseCase: resolver.resolve(FetchNoticeDetailUseCase.self)!
+            )
+        }
+
+        // 2. ViewController 등록: Reactor와 동일하게 argument를 전달합니다.
+        container.register(NoticeDetailViewController.self) { (resolver: Resolver, noticeID: Int) in
+            NoticeDetailViewController(
+                resolver.resolve(NoticeDetailReactor.self, argument: noticeID)!
+            )
+        }
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/12-notice-detail-flow.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/12-notice-detail-flow.swift
@@ -1,0 +1,47 @@
+import UIKit
+import Presentation
+import Swinject
+import RxFlow
+import Core
+
+public final class NoticeDetailFlow: Flow {
+    public let container: Container
+
+    // ✅ private let (var 아님) — init에서 resolve하므로 항상 non-nil
+    private let rootViewController: NoticeDetailViewController
+
+    public var root: Presentable {
+        return rootViewController
+    }
+
+    // ✅ noticeID를 init에서 받아 즉시 resolve
+    // ❌ navigate(to:) 안에서 resolve하면 flow.root 접근 시 nil 크래시 발생
+    public init(container: Container, noticeID: Int) {
+        self.container = container
+        self.rootViewController = container.resolve(
+            NoticeDetailViewController.self,
+            argument: noticeID
+        )!
+    }
+
+    public func navigate(to step: Step) -> FlowContributors {
+        guard let step = step as? NoticeDetailStep else { return .none }
+
+        switch step {
+        case .noticeDetailIsRequired:
+            return navigateToNoticeDetail()
+        case .noticeListIsRequired:
+            rootViewController.navigationController?.popViewController(animated: true)
+            return .none
+        }
+    }
+}
+
+private extension NoticeDetailFlow {
+    func navigateToNoticeDetail() -> FlowContributors {
+        return .one(flowContributor: .contribute(
+            withNextPresentable: rootViewController,
+            withNextStepper: rootViewController.reactor
+        ))
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/13-notice-flow-parent.swift
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/AddNewFeature/Resources/13-notice-flow-parent.swift
@@ -1,0 +1,51 @@
+import UIKit
+import Presentation
+import Swinject
+import RxFlow
+import Core
+
+public final class NoticeFlow: Flow {
+    public let container: Container
+    private let rootViewController: NoticeViewController
+
+    public var root: Presentable { return rootViewController }
+
+    public init(container: Container) {
+        self.container = container
+        self.rootViewController = container.resolve(NoticeViewController.self)!
+    }
+
+    public func navigate(to step: Step) -> FlowContributors {
+        guard let step = step as? NoticeStep else { return .none }
+
+        switch step {
+        case .noticeIsRequired:
+            return navigateToNotice()
+        case let .noticeDetailIsRequired(id):
+            return navigateToNoticeDetail(id)
+        }
+    }
+}
+
+private extension NoticeFlow {
+    func navigateToNotice() -> FlowContributors {
+        return .one(flowContributor: .contribute(
+            withNextPresentable: rootViewController,
+            withNextStepper: rootViewController.reactor
+        ))
+    }
+
+    func navigateToNoticeDetail(_ id: Int) -> FlowContributors {
+        // ✅ id를 Flow의 init에 직접 전달
+        let noticeDetailFlow = NoticeDetailFlow(container: container, noticeID: id)
+
+        Flows.use(noticeDetailFlow, when: .created) { root in
+            self.rootViewController.navigationController?.pushViewController(root, animated: true)
+        }
+
+        return .one(flowContributor: .contribute(
+            withNextPresentable: noticeDetailFlow,
+            withNextStepper: OneStepper(withSingleStep: NoticeDetailStep.noticeDetailIsRequired)
+        ))
+    }
+}

--- a/Projects/Domain/Documentation/Domain.docc/Tutorials/JOBIS.tutorial
+++ b/Projects/Domain/Documentation/Domain.docc/Tutorials/JOBIS.tutorial
@@ -1,0 +1,13 @@
+@Tutorials(name: "JOBIS iOS 개발 가이드") {
+    @Intro(title: "JOBIS iOS 개발 가이드") {
+        JOBIS는 Clean Architecture + ReactorKit + RxFlow 패턴을 사용합니다.
+        이 가이드에서는 새로운 기능 화면을 처음부터 추가하는 전체 과정을 다룹니다.
+    }
+
+    @Chapter(name: "새 화면 추가하기") {
+        Core → Domain → Data → Presentation → Flow 순서로
+        8단계에 걸쳐 공지사항 기능을 직접 만들어봅니다.
+
+        @TutorialReference(tutorial: "doc:AddNewFeature")
+    }
+}

--- a/Projects/Domain/Project.swift
+++ b/Projects/Domain/Project.swift
@@ -8,5 +8,6 @@ let project = Project.makeModule(
     targets: [.unitTest],
     dependencies: [
         .Modules.utility
-    ]
+    ],
+    sources: ["Sources/**", "Documentation/**/*.docc"]
 )


### PR DESCRIPTION
## Summary

- `Domain` 모듈에 `Domain.docc` 카탈로그 추가
- 공지사항 기능을 예시로 8단계 개발 튜토리얼 작성 (Core → Domain → Data → Presentation → Flow)
- `Domain/Project.swift` sources에 `.docc` 경로 추가 (Compile Sources 빌드 페이즈 포함)

## Test plan

- [ ] `tuist generate` 후 Xcode 재실행
- [ ] `Domain` 타겟 선택 → `Product → Build Documentation`
- [ ] Xcode Documentation 탭에서 **"JOBIS iOS 개발 가이드"** 튜토리얼 확인
- [ ] 8단계 각 섹션 및 코드 스니펫 정상 렌더링 확인

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Documentation**
  * Domain 모듈 구조 및 역할에 대한 상세 문서 추가
  * 새로운 기능 추가 8단계 튜토리얼 및 실제 코드 예제 추가
  * JOBIS iOS 개발 가이드 메인 튜토리얼 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->