### PR TITLE
🐛 :: (#446) WritableReviewReactor의 state 재귀 참조로 인한 크래시 수정

### DIFF
--- a/Projects/Flow/Sources/MyPage/MyPageFlow.swift
+++ b/Projects/Flow/Sources/MyPage/MyPageFlow.swift
@@ -2,12 +2,14 @@ import UIKit
 import Presentation
 import Swinject
 import RxFlow
+import RxSwift
 import Domain
 import Core
 
 public final class MyPageFlow: Flow {
     public let container: Container
     private let rootViewController = BaseNavigationController()
+    private let disposeBag = DisposeBag()
     public var root: Presentable {
         return rootViewController
     }
@@ -85,11 +87,13 @@ extension MyPageFlow {
             let view = root as? WritableReviewViewController
             view?.reactor.companyID = id
             if let useCase = self.container.resolve(FetchCompanyInfoDetailUseCase.self) {
-                _ = useCase.execute(id: id)
+                useCase.execute(id: id)
+                    .observe(on: MainScheduler.instance)
                     .subscribe(onSuccess: { entity in
                         view?.reactor.companyName = entity.companyName
                         view?.navigationItem.title = entity.companyName
                     }, onFailure: { _ in })
+                    .disposed(by: self.disposeBag)
             }
             self.rootViewController.pushViewController(
                 view!, animated: true

--- a/Projects/Presentation/Sources/WritableReview/WritableReviewReactor.swift
+++ b/Projects/Presentation/Sources/WritableReview/WritableReviewReactor.swift
@@ -37,10 +37,8 @@ public final class WritableReviewReactor: BaseReactor, Stepper {
 extension WritableReviewReactor {
     public func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let interviewReviewMutation = interviewReviewInfo
-            .withLatestFrom(state.map { $0.qnaInfoList }) { newInfo, oldList -> [QnAEntity] in
-                var newList = oldList
-                newList.append(newInfo)
-                return newList
+            .scan([QnAEntity]()) { oldList, newInfo in
+                oldList + [newInfo]
             }
             .map { Mutation.setQnAInfoList($0) }
 


### PR DESCRIPTION
## 개요
> 마이페이지 "작성하러 가기 →" 버튼을 누르면 WritableReview 화면 진입 시 100% 크래시가 발생하는 문제를 수정합니다.

`WritableReviewReactor.transform(mutation:)`이 ReactorKit의 `state` 스트림이 생성 완료되기 전에 `self.state`를 참조하면서 무한 재귀(`createStateStream()` → `transform(mutation:)` → `self.state` → `createStateStream()` ...)에 빠져 스택 오버플로(`EXC_BAD_ACCESS`)가 발생했습니다.

## 작업사항
- [x] `WritableReviewReactor.transform(mutation:)`에서 `self.state` 참조를 제거하고 `interviewReviewInfo` 스트림 자체에 `scan`을 적용해 리스트를 누적하도록 변경
- [x] `MyPageFlow.navigateToWritableReview(id:)`의 네트워크 응답 구독에 `.observe(on: MainScheduler.instance)`를 추가해 콜백이 메인 스레드에서 실행되도록 보장
- [x] 버려지던 `Disposable`을 `disposeBag`에 보관하도록 수정

## UI
화면 동작 변화 없음 (크래시 수정)

Closes #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 작성 중인 리뷰의 Q&A 항목이 추가될 때 목록이 더 안정적으로 누적되도록 개선했습니다.
  * 리뷰 작성 화면으로 이동한 뒤 회사명과 शीर्ष이 더 자연스럽게 반영되도록 처리했습니다.
  * 일부 비동기 처리로 인한 화면 업데이트 불안정 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->