### PR TITLE
✨ :: (#448) 알림 읽음/안읽음 필터링 구현

### DIFF
--- a/Projects/Data/Sources/DataSource/API/NotificationsAPI.swift
+++ b/Projects/Data/Sources/DataSource/API/NotificationsAPI.swift
@@ -52,11 +52,7 @@ extension NotificationsAPI: JobisAPI {
     public var task: Task {
         switch self {
         case .fetchNotificationList:
-            return .requestParameters(
-                parameters:
-//                  // TODO: 추후 읽음와 안읽음 분기처리 필요
-                    ["is_new": ""],
-                encoding: URLEncoding.queryString)
+            return .requestPlain
 
         case let .subscribeNotification(token, notificationType):
             return .requestParameters(

--- a/Projects/Presentation/Sources/Home/Alarm/AlarmReactor.swift
+++ b/Projects/Presentation/Sources/Home/Alarm/AlarmReactor.swift
@@ -6,6 +6,10 @@ import RxFlow
 import Core
 import Domain
 
+public enum NotificationFilter {
+    case all, unread, read
+}
+
 public final class AlarmReactor: BaseReactor, Stepper {
     public let steps = PublishRelay<Step>()
     public let initialState: State
@@ -24,15 +28,25 @@ public final class AlarmReactor: BaseReactor, Stepper {
     public enum Action {
         case fetchNotificationList
         case readNotification(NotificationEntity, Int)
+        case filterChanged(NotificationFilter)
     }
 
     public enum Mutation {
         case setNotificationList([NotificationEntity])
         case updateNotification(index: Int, notification: NotificationEntity)
+        case setFilter(NotificationFilter)
     }
 
     public struct State {
         var notificationList: [NotificationEntity] = []
+        var filter: NotificationFilter = .all
+        var filteredList: [NotificationEntity] {
+            switch filter {
+            case .all:    return notificationList
+            case .unread: return notificationList.filter { $0.new }
+            case .read:   return notificationList.filter { !$0.new }
+            }
+        }
     }
 }
 
@@ -58,6 +72,9 @@ extension AlarmReactor {
             )
             return readNotificationUseCase.execute(id: notification.notificationID)
                 .andThen(.just(.updateNotification(index: index, notification: updatedNotification)))
+
+        case .filterChanged(let filter):
+            return .just(.setFilter(filter))
         }
     }
 
@@ -71,6 +88,9 @@ extension AlarmReactor {
             if index < newState.notificationList.count {
                 newState.notificationList[index] = notification
             }
+
+        case let .setFilter(filter):
+            newState.filter = filter
         }
         return newState
     }

--- a/Projects/Presentation/Sources/Home/Alarm/AlarmViewController.swift
+++ b/Projects/Presentation/Sources/Home/Alarm/AlarmViewController.swift
@@ -15,14 +15,23 @@ public final class AlarmViewController: BaseReactorViewController<AlarmReactor> 
         $0.rowHeight = UITableView.automaticDimension
         $0.estimatedRowHeight = 100
     }
+    private let filterSegment = UISegmentedControl(items: ["전체", "안읽음", "읽음"]).then {
+        $0.selectedSegmentIndex = 0
+    }
 
     public override func addView() {
+        self.view.addSubview(filterSegment)
         self.view.addSubview(alarmTableView)
     }
 
     public override func setLayout() {
+        filterSegment.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide).offset(8)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(32)
+        }
         alarmTableView.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(filterSegment.snp.bottom).offset(8)
             $0.leading.trailing.bottom.equalToSuperview()
         }
     }
@@ -40,10 +49,24 @@ public final class AlarmViewController: BaseReactorViewController<AlarmReactor> 
         .map { AlarmReactor.Action.readNotification($0.0, $0.1.row) }
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
+
+        filterSegment.rx.selectedSegmentIndex
+            .skip(1)
+            .map { index -> AlarmReactor.Action in
+                let filter: NotificationFilter
+                switch index {
+                case 1: filter = .unread
+                case 2: filter = .read
+                default: filter = .all
+                }
+                return .filterChanged(filter)
+            }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
 
     public override func bindState() {
-        reactor.state.map { $0.notificationList }
+        reactor.state.map { $0.filteredList }
             .bind(to: alarmTableView.rx.items(
                 cellIdentifier: AlarmTableViewCell.identifier,
                 cellType: AlarmTableViewCell.self


### PR DESCRIPTION
## Summary

- `NotificationsAPI.fetchNotificationList`의 의미없는 `["is_new": ""]` 파라미터 제거 → `.requestPlain`으로 교체
- `AlarmReactor`에 `NotificationFilter` enum(all/unread/read) 및 클라이언트 사이드 필터 로직 추가
- `AlarmViewController`에 세그먼트 컨트롤(전체/안읽음/읽음) UI 추가 및 `filteredList` 바인딩

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `NotificationsAPI.swift` | `is_new` 파라미터 제거, TODO 주석 제거 |
| `AlarmReactor.swift` | `NotificationFilter` enum, `filterChanged` Action, `setFilter` Mutation, `filteredList` computed property 추가 |
| `AlarmViewController.swift` | `UISegmentedControl` 추가, `filteredList` 바인딩 |

## Test plan

- [ ] 알림 화면 진입 시 전체 목록 표시 확인
- [ ] "안읽음" 탭 선택 시 `new == true` 항목만 표시 확인
- [ ] "읽음" 탭 선택 시 `new == false` 항목만 표시 확인
- [ ] 알림 탭 후 읽음 처리 → 현재 필터 기준으로 즉시 반영 확인

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 알림 목록 상단에 필터를 추가해 전체/안읽음/읽음으로 바로 전환할 수 있게 되었습니다.
  * 선택한 필터에 따라 목록이 즉시 변경되도록 개선되었습니다.

* **Bug Fixes**
  * 알림 목록 조회 방식이 단순화되어 더 안정적으로 동작하도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->