### PR TITLE
🐛 :: (#450) iPad 멀티윈도우 미지원 상태에서 SupportsMultipleScenes 비활성화

### DIFF
--- a/Projects/App/Support/Info.plist
+++ b/Projects/App/Support/Info.plist
@@ -37,7 +37,7 @@
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<true/>
+		<false/>
 		<key>UISceneConfigurations</key>
 		<dict>
 			<key>UIWindowSceneSessionRoleApplication</key>


### PR DESCRIPTION
## 개요
> Apple의 [scene-based life cycle 마이그레이션 가이드](https://developer.apple.com/documentation/UIKit/transitioning-to-the-uikit-scene-based-life-cycle)를 기준으로 프로젝트 설정을 점검하던 중, `Info.plist`의 `UIApplicationSupportsMultipleScenes`가 `true`로 설정되어 있는데 실제 앱 구조는 멀티 scene 동시 실행을 지원하지 않는 불일치를 발견하여 수정합니다.

`AppDelegate.container`가 `static var`로 앱 전역에 하나만 존재하고, `SceneDelegate`가 scene 연결 시마다 `FlowCoordinator`/`AppFlow`를 새로 생성하지만 동일한 static DI 컨테이너를 여러 scene 인스턴스가 동시에 사용하는 상황은 검증되어 있지 않습니다. iPad에서 사용자가 앱을 새 창으로 띄우면 의도치 않게 같은 의존성 그래프를 공유하는 화면이 중복 생성될 수 있습니다.

## 작업사항
- [x] `Projects/App/Support/Info.plist`의 `UIApplicationSupportsMultipleScenes`를 `false`로 변경

## UI
화면 동작 변화 없음 (iPad에서 새 창으로 앱 인스턴스를 추가로 띄우는 옵션이 사라짐)

Closes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 앱의 다중 장면(multiple scenes) 지원 설정이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->